### PR TITLE
fix(esx_vehicleshop): increase security on sell vehicle

### DIFF
--- a/[esx_addons]/esx_vehicleshop/client/main.lua
+++ b/[esx_addons]/esx_vehicleshop/client/main.lua
@@ -770,6 +770,7 @@ CreateThread(function()
 end)
 
 -- Key controls
+local isReselling = false
 CreateThread(function()
 	while true do
 		Wait(0)
@@ -793,23 +794,35 @@ CreateThread(function()
 				elseif CurrentAction == 'reseller_menu' then
 					OpenResellerMenu()
 				elseif CurrentAction == 'give_back_vehicle' then
-					ESX.TriggerServerCallback('esx_vehicleshop:giveBackVehicle', function(isRentedVehicle)
-						if isRentedVehicle then
-							ESX.Game.DeleteVehicle(CurrentActionData.vehicle)
-							ESX.ShowNotification(TranslateCap('delivered'))
-						else
-							ESX.ShowNotification(TranslateCap('not_rental'))
-						end
-					end, ESX.Math.Trim(GetVehicleNumberPlateText(CurrentActionData.vehicle)))
+					if not isReselling then
+						isReselling = true
+						ESX.TriggerServerCallback('esx_vehicleshop:giveBackVehicle', function(isRentedVehicle)
+							if isRentedVehicle then
+								ESX.Game.DeleteVehicle(CurrentActionData.vehicle)
+								ESX.ShowNotification(TranslateCap('delivered'))
+							else
+								ESX.ShowNotification(TranslateCap('not_rental'))
+							end
+							isReselling = false
+						end, ESX.Math.Trim(GetVehicleNumberPlateText(CurrentActionData.vehicle)))
+					end
 				elseif CurrentAction == 'resell_vehicle' then
-					ESX.TriggerServerCallback('esx_vehicleshop:resellVehicle', function(vehicleSold)
-						if vehicleSold then
-							ESX.Game.DeleteVehicle(CurrentActionData.vehicle)
-							ESX.ShowNotification(TranslateCap('vehicle_sold_for', CurrentActionData.label, ESX.Math.GroupDigits(CurrentActionData.price)))
-						else
-							ESX.ShowNotification(TranslateCap('not_yours'))
-						end
-					end, CurrentActionData.plate, CurrentActionData.model)
+					if not isReselling then
+						isReselling = true
+						ESX.TriggerServerCallback('esx_vehicleshop:resellVehicle', function(vehicleSold)
+							if vehicleSold then
+								ESX.Game.DeleteVehicle(CurrentActionData.vehicle)
+								ESX.ShowNotification(TranslateCap('vehicle_sold_for', CurrentActionData.label, ESX.Math.GroupDigits(CurrentActionData.price)))
+							else
+								ESX.ShowNotification(TranslateCap('not_yours'))
+							end
+
+							CurrentAction = nil
+							CurrentActionData = {}
+							CurrentActionMsg = nil
+							isReselling = false
+						end, CurrentActionData.plate, CurrentActionData.model)
+					end
 				elseif CurrentAction == 'boss_actions_menu' then
 					OpenBossActionsMenu()
 				end


### PR DESCRIPTION
### Description
Adds extra security to selling vehicles in vehicleshop

---
### Motivation
Intended to patch https://github.com/esx-framework/esx_vehicleshop/issues/49

---

### **Implementation Details**
Adds client-sided toggle states to make sure its not being spammed, makes sure to reset the data afterwards, to stop spamming, makes the server-side confirm a vehicle was removed before giving money
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- []  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
