### PR TITLE
feat(esx_ambulancejob): add optional death anim

### DIFF
--- a/[esx_addons]/esx_ambulancejob/client/job.lua
+++ b/[esx_addons]/esx_ambulancejob/client/job.lua
@@ -131,8 +131,9 @@ function revivePlayer(closestPlayer)
 	ESX.TriggerServerCallback('esx_ambulancejob:getItemAmount', function(quantity)
 		if quantity > 0 then
 			local closestPlayerPed = GetPlayerPed(closestPlayer)
+			local closestPlayerSrc = GetPlayerServerId(NetworkGetPlayerIndexFromPed(closestPlayerPed))
 
-			if IsPedDeadOrDying(closestPlayerPed, 1) then
+			if Player(closestPlayerSrc).state.isDead then
 				local playerPed = PlayerPedId()
 				local lib, anim = 'mini@cpr@char_a@cpr_str', 'cpr_pumpchest'
 				ESX.ShowNotification(TranslateCap('revive_inprogress'))

--- a/[esx_addons]/esx_ambulancejob/config.lua
+++ b/[esx_addons]/esx_ambulancejob/config.lua
@@ -9,6 +9,20 @@ Config.LoadIpl                    = true -- Disable if you're using fivem-ipl or
 
 Config.Locale = GetConvar('esx:locale', 'en')
 
+-- Prevents desync on dead players by skipping ragdoll.
+-- Players are revived instantly and play an animation instead.
+-- Note: Natives like "IsPedFatallyInjured" will no longer work reliably.
+-- Use Player(src).state.isDead for death checks.
+Config.DeathAnim = {
+    enabled = true,
+    dict = "misslamar1dead_body",
+    name = "dead_idle",
+	fadeIn = 10.0,
+	fadeOut = 10.0,
+	flags = 1|2|8,
+	playbackRate = 1.0
+}
+
 Config.DistressBlip = {
 	Sprite = 310,
 	Color = 48,

--- a/[esx_addons]/esx_policejob/client/main.lua
+++ b/[esx_addons]/esx_policejob/client/main.lua
@@ -1105,7 +1105,7 @@ CreateThread(function()
 			Sleep = 50
 			local targetPed = GetPlayerPed(GetPlayerFromServerId(dragStatus.CopId))
 
-			if DoesEntityExist(targetPed) and IsPedOnFoot(targetPed) and not IsPedDeadOrDying(targetPed, true) then
+			if DoesEntityExist(targetPed) and IsPedOnFoot(targetPed) and not Player(dragStatus.CopId).state.isDead then
 				if not wasDragged then
 					AttachEntityToEntity(ESX.PlayerData.ped, targetPed, 11816, 0.54, 0.54, 0.0, 0.0, 0.0, 0.0, false, false, false, false, 2, true)
 					wasDragged = true


### PR DESCRIPTION
### Description

This PR introduces an **optional death animation** to avoid player desync when dying.  
When enabled, ragdoll physics on death are skipped, players are instantly revived, and a custom animation plays instead.  

As a side effect, `esx_ambulancejob` and `esx_policejob` have been updated to use the `Player(src).state.isDead` statebag for death checks instead of relying on natives like `IsPedFatallyInjured`.  
This makes death detection compatible regardless of whether the death animation is used or not.

---

### Motivation

- Ragdolled peds are not synced between clients, which will cause dead players to appear in different positions on different clients.  
- Many death screens attempt to "resync" the player by briefly clearing the ragdoll, but this is only a partial fix.  
- This PR completely resolves the issue by skipping ragdoll entirely and playing a fully synchronized death animation, ensuring all clients see the same player state and position.


---

### Implementation Details

- **New Config:** `Config.DeathAnim`
    ```lua
    -- Prevents desync on dead players by skipping ragdoll.
    -- Players are revived instantly and play an animation instead.
    -- Note: Natives like "IsPedFatallyInjured" will no longer work reliably.
    -- Use Player(src).state.isDead for death checks.
    Config.DeathAnim = {
        enabled = true,
        dict = "misslamar1dead_body",
        name = "dead_idle",
        fadeIn = 10.0,
        fadeOut = 10.0,
        flags = 1|2|8,
        playbackRate = 1.0
    }
    ```
- Updated `esx_ambulancejob` and `esx_policejob` to:
    - Use statebag-based death checks.

---

### PR Checklist

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.

