### PR TITLE
feat(esx_service): Synchronize duty with ESX core

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+### Description
+
+<!-- What does this PR do? Summarize the feature, fix, or improvement. -->
+
+---
+
+### Motivation
+
+<!-- Why are these changes necessary? What problem does it solve? -->
+
+---
+
+### Implementation Details
+
+<!-- How is it implemented? Highlight key technical decisions or logic. -->
+
+---
+
+### Usage Example
+
+```lua
+-- Add example usage here
+```
+
+---
+
+### PR Checklist
+
+-   [ ] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
+-   [ ] My changes have been tested locally and function as expected.
+-   [ ] My PR does not introduce any breaking changes.
+-   [ ] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.

--- a/[esx_addons]/esx_service/server/main.lua
+++ b/[esx_addons]/esx_service/server/main.lua
@@ -1,7 +1,9 @@
 local InService    = {}
 local MaxInService = {}
+local PlayersJob = {}
 
 function GetInServiceCount(name)
+	if InService[name] == nil then return 0 end
 	local count = 0
 
 	for k,v in pairs(InService[name]) do
@@ -13,17 +15,52 @@ function GetInServiceCount(name)
 	return count
 end
 
+AddEventHandler('esx:playerLoaded', function (playerId, xPlayer, isNew)
+	local job = xPlayer.job
+	PlayersJob[playerId] = xPlayer.job
+	if InService[job.name] then
+		InService[job.name][playerId] = job.onDuty
+	end
+end)
+
+AddEventHandler('esx:setJob', function(source,job,lastJob)
+    PlayersJob[source] = job
+end)
+
+local function checkPlayersService(name)
+	local jobPlayers = ESX.GetExtendedPlayers('job', name)
+	
+	for i, xPlayer in ipairs(jobPlayers) do
+		InService[name][xPlayer.source] = xPlayer.job.onDuty
+	end
+end
+
+local function setDuty(playerId, status)
+	local xPlayer = ESX.GetPlayerFromId(playerId)
+	local job = PlayersJob[playerId]
+
+	xPlayer.setJob(job.name, job.grade, status)
+end
+
 RegisterServerEvent('esx_service:activateService')
 AddEventHandler('esx_service:activateService', function(name, max)
+	if not name or not max then return end
+	
 	InService[name] = {}
 	MaxInService[name] = max
 	GlobalState[name] = GetInServiceCount(name)
+	checkPlayersService(name)
 end)
 
 RegisterServerEvent('esx_service:disableService')
-AddEventHandler('esx_service:disableService', function(name)
-	InService[name][source] = nil
-	GlobalState[name] = GetInServiceCount(name)
+AddEventHandler('esx_service:disableService', function()
+	local job = PlayersJob[source]
+
+	if not InService[job.name] then return end
+
+	InService[job.name][source] = nil
+	GlobalState[job.name] = GetInServiceCount(job.name)
+	setDuty(source, false)
 end)
 
 RegisterServerEvent('esx_service:notifyAllInService')
@@ -35,39 +72,36 @@ AddEventHandler('esx_service:notifyAllInService', function(notification, name)
 	end
 end)
 
-ESX.RegisterServerCallback('esx_service:enableService', function(source, cb, name)
-	local inServiceCount = GetInServiceCount(name)
+ESX.RegisterServerCallback('esx_service:enableService', function(source, cb)
+	local job = PlayersJob[source]
+
+	local inServiceCount = GetInServiceCount(job.name)
 	
-	if inServiceCount >= MaxInService[name] then
-		cb(false, MaxInService[name], inServiceCount)
+	if inServiceCount >= MaxInService[job.name] then
+		cb(false, MaxInService[job.name], inServiceCount)
 	else
-		InService[name][source] = true
-		GlobalState[name] = GetInServiceCount(name)
-		cb(true, MaxInService[name], inServiceCount)		
+		InService[job.name][source] = true
+		GlobalState[job.name] = GetInServiceCount(job.name)
+		setDuty(source, true)
+		cb(true, MaxInService[job.name], inServiceCount)		
 	end
 end)
 
-ESX.RegisterServerCallback('esx_service:isInService', function(source, cb, name)
-	local isInService = false
+ESX.RegisterServerCallback('esx_service:isInService', function(source, cb)
+	local job = PlayersJob[source]
+	local isInService = job and job.onDuty or false
 
-	if InService[name] ~= nil then
-		if InService[name][source] then
-			isInService = true
-		end
-	else
-		print(('[^3WARNING^7] Attempted To Use Inactive Service - ^5%s^7'):format(name))
+	if InService[job.name] == nil then
+		print(('[^3WARNING^7] Attempted To Use Inactive Service - ^5%s^7'):format(job.name))
 	end
 
 	cb(isInService)
 end)
 
-ESX.RegisterServerCallback('esx_service:isPlayerInService', function(source, cb, name, target)
-	local isPlayerInService = false
-	local targetXPlayer = ESX.GetPlayerFromId(target)
+ESX.RegisterServerCallback('esx_service:isPlayerInService', function(source, cb, _, target)
+	local job = PlayersJob[target]
 
-	if InService[name][targetXPlayer.source] then
-		isPlayerInService = true
-	end
+	local isPlayerInService = job and job.onDuty or false
 
 	cb(isPlayerInService)
 end)
@@ -77,10 +111,20 @@ ESX.RegisterServerCallback('esx_service:getInServiceList', function(source, cb, 
 end)
 
 AddEventHandler('esx:playerDropped', function(playerId, reason)
+	PlayersJob[playerId] = nil
 	for k,v in pairs(InService) do
 		if v[playerId] == true then
 			v[playerId] = nil
 			GlobalState[k] = GetInServiceCount(k)
 		end
+	end
+end)
+
+AddEventHandler('onResourceStart', function(resourceName)
+  if (GetCurrentResourceName() ~= resourceName) then return end
+  local xPlayers = ESX.GetExtendedPlayers()
+ 
+	for i, xPlayer in ipairs(xPlayers) do
+		PlayersJob[xPlayer.source] = xPlayer.job
 	end
 end)


### PR DESCRIPTION
### Description

These changes would not require changes to those using the current logic.

---

### Motivation

Previously, `esx_service` only tracked players in service and did not update their core duty status `(xPlayer.job.onDuty)`.
This PR ensures that when a player goes on or off service, their duty status in the core is updated, keeping ESX Core consistent.

---

### Implementation Details

Added `PlayersJob` to store connected players’ jobs.

Updated events (`esx:playerLoaded`, `esx:setJob`, `esx:playerDropped`) to keep `PlayersJob` in sync.

When activating or disabling a service, the player’s onDuty status is updated via `xPlayer.setJob(job.name, job.grade, status)`.

Synchronized all players’ duty status in a job when a service is activated.

---

### Usage Example

```lua
-- Activate service with a maximum of 5 medics
TriggerEvent('esx_service:activateService', 'ambulance', 5)

-- Player goes on duty
ESX.TriggerServerCallback('esx_service:enableService', function(success, max, count)
    if success then
        print(("You are now on duty. Total: %d/%d"):format(count+1, max))
    else
        print(("Service full: %d/%d"):format(count, max))
    end
end)

-- Player goes off duty
TriggerServerEvent('esx_service:disableService')
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
