### PR TITLE
refactor(esx_addonaccount): rewrite

### DIFF
--- a/[esx_addons]/esx_addonaccount/fxmanifest.lua
+++ b/[esx_addons]/esx_addonaccount/fxmanifest.lua
@@ -1,10 +1,11 @@
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
+use_fxv2_oal 'yes'
 
 author 'ESX-Framework'
-description 'Allows resources to store account data, such as society funds'
-lua54 'yes'
-version '1.1'
+description 'Allows resources to store account data, such as society funds.'
+version '1.2'
 legacyversion '1.13.4'
 
 server_scripts {
@@ -14,10 +15,9 @@ server_scripts {
 	'server/main.lua'
 }
 
-server_exports {
-	'GetSharedAccount',
-	'AddSharedAccount',
-	'GetAccount'
-}
-
-dependency 'es_extended'
+-- @todo remove, kept just for overview
+-- server_exports {
+-- 	'GetSharedAccount',
+-- 	'AddSharedAccount',
+-- 	'GetAccount'
+-- }

--- a/[esx_addons]/esx_addonaccount/fxmanifest.lua
+++ b/[esx_addons]/esx_addonaccount/fxmanifest.lua
@@ -14,10 +14,3 @@ server_scripts {
 	'server/classes/addonaccount.lua',
 	'server/main.lua'
 }
-
--- @todo remove, kept just for overview
--- server_exports {
--- 	'GetSharedAccount',
--- 	'AddSharedAccount',
--- 	'GetAccount'
--- }

--- a/[esx_addons]/esx_addonaccount/fxmanifest.lua
+++ b/[esx_addons]/esx_addonaccount/fxmanifest.lua
@@ -12,5 +12,6 @@ server_scripts {
 	'@es_extended/imports.lua',
 	'@oxmysql/lib/MySQL.lua',
 	'server/classes/addonaccount.lua',
+	'server/database.lua',
 	'server/main.lua'
 }

--- a/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
+++ b/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
@@ -5,6 +5,7 @@
 ---@field addMoney fun(amount: number): boolean
 ---@field removeMoney fun(amount: number): boolean
 ---@field setMoney fun(amount: number): boolean
+---@field transferMoney fun(target: TransactionAccount, amount: number): boolean
 ---@field save function
 
 ---@param name string
@@ -42,6 +43,18 @@ function CreateAddonAccount(name, owner, money)
 
 		TriggerEvent('esx_addonaccount:setMoney', self.name, amount)
 		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
+		return true
+	end
+
+	function self.transferMoney(target, amount)
+		local targetAccount = GetTransactionAccount(target)
+		if not targetAccount then return false end
+
+		if not self.removeMoney(amount) then
+			return false
+		end
+
+		targetAccount.addMoney(amount)
 		return true
 	end
 

--- a/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
+++ b/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
@@ -21,35 +21,26 @@ function CreateAddonAccount(name, owner, money)
 
 	function self.addMoney(amount)
 		self.money += amount
-		self.save()
 
 		TriggerEvent('esx_addonaccount:addMoney', self.name, amount)
+		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
 	end
 
 	function self.removeMoney(amount)
 		self.money -= amount
-		self.save()
 
 		TriggerEvent('esx_addonaccount:removeMoney', self.name, amount)
+		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
 	end
 
 	function self.setMoney(amount)
 		self.money = amount
-		self.save()
 
 		TriggerEvent('esx_addonaccount:setMoney', self.name, amount)
+		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
 	end
 
 	function self.save()
-		local query, params = 'UPDATE addon_account_data SET money = ? WHERE account_name = ?', { self.money, self.name }
-
-		if self.owner then
-			query = query .. ' AND owner = ?'
-			table.insert(params, self.owner)
-		end
-
-		MySQL.update.await(query, params)
-		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
 	end
 
 	return self

--- a/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
+++ b/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
@@ -1,35 +1,54 @@
-function CreateAddonAccount(name, owner, money)
-	local self = {}
+---@class AddonAccount
+---@field name string
+---@field owner? string
+---@field money number
+---@field addMoney fun(amount: number)
+---@field removeMoney fun(amount: number)
+---@field setMoney fun(amount: number)
+---@field save function
 
-	self.name  = name
+---@param name string
+---@param owner? string
+---@param money number
+---@return AddonAccount
+function CreateAddonAccount(name, owner, money)
+	---@diagnostic disable-next-line: missing-fields
+	local self = {} --[[@type AddonAccount]]
+
+	self.name = name
 	self.owner = owner
 	self.money = money
 
 	function self.addMoney(amount)
-		self.money = self.money + amount
+		self.money += amount
 		self.save()
+
 		TriggerEvent('esx_addonaccount:addMoney', self.name, amount)
 	end
 
 	function self.removeMoney(amount)
-		self.money = self.money - amount
+		self.money -= amount
 		self.save()
+
 		TriggerEvent('esx_addonaccount:removeMoney', self.name, amount)
 	end
 
 	function self.setMoney(amount)
 		self.money = amount
 		self.save()
+
 		TriggerEvent('esx_addonaccount:setMoney', self.name, amount)
 	end
 
 	function self.save()
-		if self.owner == nil then
-			MySQL.update('UPDATE addon_account_data SET money = ? WHERE account_name = ?', { self.money, self.name })
-		else
-			MySQL.update('UPDATE addon_account_data SET money = ? WHERE account_name = ? AND owner = ?',
-				{ self.money, self.name, self.owner })
+		local query, params = 'UPDATE addon_account_data SET money = ? WHERE account_name = ?', { self.money, self.name }
+
+		if self.owner then
+			query = query .. ' AND owner = ?'
+			table.insert(params, self.owner)
 		end
+
+		MySQL.update.await(query, params)
 		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
 	end
 

--- a/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
+++ b/[esx_addons]/esx_addonaccount/server/classes/addonaccount.lua
@@ -2,9 +2,9 @@
 ---@field name string
 ---@field owner? string
 ---@field money number
----@field addMoney fun(amount: number)
----@field removeMoney fun(amount: number)
----@field setMoney fun(amount: number)
+---@field addMoney fun(amount: number): boolean
+---@field removeMoney fun(amount: number): boolean
+---@field setMoney fun(amount: number): boolean
 ---@field save function
 
 ---@param name string
@@ -24,13 +24,17 @@ function CreateAddonAccount(name, owner, money)
 
 		TriggerEvent('esx_addonaccount:addMoney', self.name, amount)
 		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
+		return true
 	end
 
 	function self.removeMoney(amount)
+		if amount > self.money then return false end
+
 		self.money -= amount
 
 		TriggerEvent('esx_addonaccount:removeMoney', self.name, amount)
 		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
+		return true
 	end
 
 	function self.setMoney(amount)
@@ -38,6 +42,7 @@ function CreateAddonAccount(name, owner, money)
 
 		TriggerEvent('esx_addonaccount:setMoney', self.name, amount)
 		TriggerClientEvent('esx_addonaccount:setMoney', -1, self.name, self.money)
+		return true
 	end
 
 	function self.save()

--- a/[esx_addons]/esx_addonaccount/server/database.lua
+++ b/[esx_addons]/esx_addonaccount/server/database.lua
@@ -33,3 +33,22 @@ function Database.fetchSharedAccount(name)
 
     return accountData
 end
+
+function Database.saveAccounts()
+    local params, n = {}, 0
+    for _, accountData in pairs(Accounts) do
+        for owner, account in pairs(accountData) do
+            n += 1
+            params[n] = { account.money, account.name, owner }
+        end
+    end
+
+    for _, account in pairs(SharedAccounts) do
+        n += 1
+        params[n] = { account.money, account.name }
+    end
+
+    MySQL.prepare.await([[
+        UPDATE addon_account_data SET money = ? WHERE account_name = ? AND owner = ?;
+    ]], params)
+end

--- a/[esx_addons]/esx_addonaccount/server/database.lua
+++ b/[esx_addons]/esx_addonaccount/server/database.lua
@@ -16,7 +16,7 @@ function Database.fetchAccount(name, owner)
     local accountData = MySQL.single.await([[
         SELECT * FROM addon_account aa
         LEFT JOIN addon_account_data aad ON aa.name = aad.account_name
-        WHERE aa.shared = 1 AND aa.name = ? AND aad.owner = ?
+        WHERE aa.shared = 0 AND aa.name = ? AND aad.owner = ?
     ]], { name, owner })
 
     return accountData

--- a/[esx_addons]/esx_addonaccount/server/database.lua
+++ b/[esx_addons]/esx_addonaccount/server/database.lua
@@ -1,0 +1,35 @@
+Database = {}
+
+---@class DatabaseAccountRow
+---@field name string
+---@field label string
+---@field shared number
+---@field id number
+---@field account_name? string
+---@field money number
+---@field owner? string
+
+---@param name string
+---@param owner string
+---@return DatabaseAccountRow?
+function Database.fetchAccount(name, owner)
+    local accountData = MySQL.single.await([[
+        SELECT * FROM addon_account aa
+        FULL OUTER JOIN addon_account_data aad ON aa.name = aad.account_name
+        WHERE aa.shared = 0 AND aa.name = ? AND aad.owner = ?
+    ]], { name, owner })
+
+    return accountData
+end
+
+---@param name string
+---@return DatabaseAccountRow?
+function Database.fetchSharedAccount(name)
+    local accountData = MySQL.single.await([[
+        SELECT * FROM addon_account aa
+        FULL OUTER JOIN addon_account_data aad ON aa.name = aad.account_name
+        WHERE aa.shared = 1 AND aa.name = ?
+    ]], { name })
+
+    return accountData
+end

--- a/[esx_addons]/esx_addonaccount/server/main.lua
+++ b/[esx_addons]/esx_addonaccount/server/main.lua
@@ -127,6 +127,39 @@ local function setSharedAccountMoney(name, amount)
     account.setMoney(amount)
 end
 
+---@alias TransactionAccount { name: string, owner?: string }|string
+
+---@param accountData TransactionAccount
+---@return AddonAccount?
+local function getTransactionAccount(accountData)
+    if type(accountData) == "string" then
+        return getSharedAccount(accountData)
+    end
+
+    if accountData.owner then
+        return getAccount(accountData.name, accountData.owner)
+    else
+        return getSharedAccount(accountData.name)
+    end
+end
+
+---@param sender TransactionAccount
+---@param receiver TransactionAccount
+---@param amount number
+---@return boolean, string
+local function transferMoney(sender, receiver, amount)
+    local senderAccount, receiverAccount = getTransactionAccount(sender), getTransactionAccount(receiver)
+    if not senderAccount or not receiverAccount then return false, 'invalid_account' end
+
+    if not senderAccount.removeMoney(amount) then
+        return false, 'insufficient_funds'
+    end
+
+    receiverAccount.addMoney(amount)
+
+    return true, 'success'
+end
+
 AddEventHandler('esx:playerLoaded', function(_, xPlayer)
     local addonAccounts = {}
 
@@ -191,3 +224,5 @@ exports('SetAccountMoney', setAccountMoney)
 exports('AddSharedAccountMoney', addSharedAccountMoney)
 exports('RemoveSharedAccountMoney', removeSharedAccountMoney)
 exports('SetSharedAccountMoney', setSharedAccountMoney)
+
+exports('TransferMoney', transferMoney)

--- a/[esx_addons]/esx_addonaccount/server/main.lua
+++ b/[esx_addons]/esx_addonaccount/server/main.lua
@@ -4,7 +4,7 @@ Accounts, SharedAccounts = {}, {}
 ---@param owner string
 ---@return AddonAccount?
 local function getAccount(name, owner)
-    local existingAccount = Accounts[name][owner]
+    local existingAccount = Accounts[name]?[owner]
     if existingAccount then
         return existingAccount
     end

--- a/[esx_addons]/esx_addonaccount/server/main.lua
+++ b/[esx_addons]/esx_addonaccount/server/main.lua
@@ -1,135 +1,176 @@
-local Accounts, SharedAccounts = {}, {}
-
-local FETCH_ACCOUNTS_QUERY = [[
-	SELECT * FROM addon_account
-	LEFT JOIN addon_account_data ON addon_account.name = addon_account_data.account_name
-	UNION
-	SELECT * FROM addon_account
-	RIGHT JOIN addon_account_data ON addon_account.name = addon_account_data.account_name
-]]
-local function initializeAccounts()
-	local accounts = MySQL.query.await(FETCH_ACCOUNTS_QUERY)
-	local newAccounts = {}
-
-	for _, accountRow in ipairs(accounts) do
-		local accountName = accountRow.name
-		if accountRow.shared == 0 then
-			if not Accounts[accountName] then
-				Accounts[accountName] = {}
-			end
-
-			local newIndex = #Accounts[accountName] + 1
-			Accounts[accountName][newIndex] = CreateAddonAccount(accountName, accountRow.owner, accountRow.money)
-		else
-			if accountRow.money then
-				SharedAccounts[accountName] = CreateAddonAccount(accountName, nil, accountRow.money)
-			else
-				newAccounts[#newAccounts + 1] = { accountName, 0 }
-			end
-		end
-	end
-
-	GlobalState.SharedAccounts = SharedAccounts
-
-	if next(newAccounts) then
-		MySQL.prepare.await('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', newAccounts)
-
-		for _, newAccount in ipairs(newAccounts) do
-			local accountName = newAccount[1]
-			SharedAccounts[accountName] = CreateAddonAccount(accountName, nil, 0)
-		end
-
-		GlobalState.SharedAccounts = SharedAccounts
-	end
-end
+Accounts, SharedAccounts = {}, {}
 
 ---@param name string
 ---@param owner string
 ---@return AddonAccount?
 local function getAccount(name, owner)
-	for _, account in ipairs(Accounts[name]) do
-		if account.owner == owner then
-			return account
-		end
-	end
+    local existingAccount = Accounts[name][owner]
+    if existingAccount then
+        return existingAccount
+    end
+
+    local dbAccount = Database.fetchAccount(name, owner)
+    if not dbAccount then return end
+
+    if not Accounts[name] then
+        Accounts[name] = {}
+    end
+
+    Accounts[name][owner] = CreateAddonAccount(name, owner, dbAccount.money)
+
+    return Accounts[name][owner]
 end
 
 ---@param name string
----@return AddonAccount
+---@return AddonAccount?
 local function getSharedAccount(name)
-	return SharedAccounts[name]
+    local existingAccount = SharedAccounts[name]
+    if existingAccount then
+        return existingAccount
+    end
+
+    local dbAccount = Database.fetchSharedAccount(name)
+    if not dbAccount then return end
+
+    local money = dbAccount.money
+    SharedAccounts[name] = CreateAddonAccount(name, nil, money or 0)
+
+    if not money then
+        MySQL.prepare.await('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', { name, 0 })
+    end
+
+    GlobalState.SharedAccounts = SharedAccounts
+
+    return SharedAccounts[name]
 end
 
 ---@param society { name: string, label: string }
 ---@param amount? number
 ---@return AddonAccount?
 local function addSharedAccount(society, amount)
-	local societyName, societyLabel = society?.name, society?.label
-	if not societyName or not societyLabel then return end
+    local societyName, societyLabel = society?.name, society?.label
+    if not societyName or not societyLabel then return end
 
-	local existingSharedAccount = SharedAccounts[societyName]
-	if existingSharedAccount then return existingSharedAccount end
+    local existingSharedAccount = getSharedAccount(societyName)
+    if existingSharedAccount then return existingSharedAccount end
 
-	local account = MySQL.insert.await('INSERT INTO `addon_account` (name, label, shared) VALUES (?, ?, ?)', { societyName, societyLabel, 1 })
-	if not account then return end
+    local account = MySQL.insert.await('INSERT INTO `addon_account` (name, label, shared) VALUES (?, ?, ?)', { societyName, societyLabel, 1 })
+    if not account then return end
 
-	amount = amount or 0
-	local accountData = MySQL.insert.await('INSERT INTO `addon_account_data` (account_name, money) VALUES (?, ?)', {
-		societyName, amount
-	})
-	if not accountData then return end
+    amount = amount or 0
+    local accountData = MySQL.insert.await('INSERT INTO `addon_account_data` (account_name, money) VALUES (?, ?)', {
+        societyName, amount
+    })
+    if not accountData then return end
 
-	SharedAccounts[societyName] = CreateAddonAccount(societyName, nil, amount)
+    SharedAccounts[societyName] = CreateAddonAccount(societyName, nil, amount)
 
-	GlobalState.SharedAccounts = SharedAccounts
+    GlobalState.SharedAccounts = SharedAccounts
 
-	return SharedAccounts[societyName]
+    return SharedAccounts[societyName]
 end
 
-AddEventHandler('onResourceStart', function(resourceName)
-	if resourceName ~= GetCurrentResourceName() then return end
+---@param name string
+---@param owner string
+---@param amount number
+local function addAccountMoney(name, owner, amount)
+    local account = getAccount(name, owner)
+    if not account then return end
 
-	initializeAccounts()
+    account.addMoney(amount)
+end
+
+---@param name string
+---@param owner string
+---@param amount number
+local function removeAccountMoney(name, owner, amount)
+    local account = getAccount(name, owner)
+    if not account then return end
+
+    account.removeMoney(amount)
+end
+
+---@param name string
+---@param owner string
+---@param amount number
+local function setAccountMoney(name, owner, amount)
+    local account = getAccount(name, owner)
+    if not account then return end
+
+    account.setMoney(amount)
+end
+
+---@param name string
+---@param amount number
+local function addSharedAccountMoney(name, amount)
+    local account = getSharedAccount(name)
+    if not account then return end
+
+    account.addMoney(amount)
+end
+
+---@param name string
+---@param amount number
+local function removeSharedAccountMoney(name, amount)
+    local account = getSharedAccount(name)
+    if not account then return end
+
+    account.removeMoney(amount)
+end
+
+---@param name string
+---@param amount number
+local function setSharedAccountMoney(name, amount)
+    local account = getSharedAccount(name)
+    if not account then return end
+
+    account.setMoney(amount)
+end
+
+AddEventHandler('esx:playerLoaded', function(_, xPlayer)
+    local addonAccounts = {}
+
+    local identifier = xPlayer.getIdentifier()
+    for _, accountName in pairs(Accounts) do
+        local account = getAccount(accountName, identifier)
+
+        if not account then
+            MySQL.insert.await('INSERT INTO addon_account_data (account_name, money, owner) VALUES (?, ?, ?)',
+                { accountName, 0, identifier })
+
+            account = CreateAddonAccount(accountName, identifier, 0)
+
+            Accounts[accountName][identifier] = account
+        end
+
+        addonAccounts[#addonAccounts + 1] = account
+    end
+
+    xPlayer.set('addonAccounts', addonAccounts)
 end)
 
 ---@param name string
 ---@param owner string
 ---@param cb function
 AddEventHandler('esx_addonaccount:getAccount', function(name, owner, cb)
-	cb(getAccount(name, owner))
+    cb(getAccount(name, owner))
 end)
 
 ---@param name string
 ---@param cb function
 AddEventHandler('esx_addonaccount:getSharedAccount', function(name, cb)
-	cb(getSharedAccount(name))
+    cb(getSharedAccount(name))
 end)
-
-AddEventHandler('esx:playerLoaded', function(_, xPlayer)
-	local addonAccounts = {}
-
-	local identifier = xPlayer.getIdentifier()
-	for _, accountName in pairs(Accounts) do
-		local account = getAccount(accountName, identifier)
-
-		if not account then
-			MySQL.insert.await('INSERT INTO addon_account_data (account_name, money, owner) VALUES (?, ?, ?)',
-				{ accountName, 0, identifier })
-
-			account = CreateAddonAccount(accountName, identifier, 0)
-
-			local newIndex = #Accounts[accountName] + 1
-			Accounts[accountName][newIndex] = account
-		end
-
-		addonAccounts[#addonAccounts + 1] = account
-	end
-
-	xPlayer.set('addonAccounts', addonAccounts)
-end)
-
-RegisterNetEvent('esx_addonaccount:refreshAccounts', initializeAccounts)
 
 exports('GetSharedAccount', getSharedAccount)
-exports('AddSharedAccount', addSharedAccount)
 exports('GetAccount', getAccount)
+
+exports('AddSharedAccount', addSharedAccount)
+
+exports('AddAccountMoney', addAccountMoney)
+exports('RemoveAccountMoney', removeAccountMoney)
+exports('SetAccountMoney', setAccountMoney)
+
+exports('AddSharedAccountMoney', addSharedAccountMoney)
+exports('RemoveSharedAccountMoney', removeSharedAccountMoney)
+exports('SetSharedAccountMoney', setSharedAccountMoney)

--- a/[esx_addons]/esx_addonaccount/server/main.lua
+++ b/[esx_addons]/esx_addonaccount/server/main.lua
@@ -1,101 +1,125 @@
-local AccountsIndex, Accounts, SharedAccounts = {}, {}, {}
+local Accounts, SharedAccounts = {}, {}
 
-AddEventHandler('onResourceStart', function(resourceName)
-	if resourceName == GetCurrentResourceName() then
-		local accounts = MySQL.query.await(
-			'SELECT * FROM addon_account LEFT JOIN addon_account_data ON addon_account.name = addon_account_data.account_name UNION SELECT * FROM addon_account RIGHT JOIN addon_account_data ON addon_account.name = addon_account_data.account_name')
+local FETCH_ACCOUNTS_QUERY = [[
+	SELECT * FROM addon_account
+	LEFT JOIN addon_account_data ON addon_account.name = addon_account_data.account_name
+	UNION
+	SELECT * FROM addon_account
+	RIGHT JOIN addon_account_data ON addon_account.name = addon_account_data.account_name
+]]
+local function initializeAccounts()
+	local accounts = MySQL.query.await(FETCH_ACCOUNTS_QUERY)
+	local newAccounts = {}
 
-		local newAccounts = {}
-		for i = 1, #accounts do
-			local account = accounts[i]
-			if account.shared == 0 then
-				if not Accounts[account.name] then
-					AccountsIndex[#AccountsIndex + 1] = account.name
-					Accounts[account.name] = {}
-				end
-				Accounts[account.name][#Accounts[account.name] + 1] = CreateAddonAccount(account.name, account.owner,
-					account.money)
+	for _, accountRow in ipairs(accounts) do
+		local accountName = accountRow.name
+		if accountRow.shared == 0 then
+			if not Accounts[accountName] then
+				Accounts[accountName] = {}
+			end
+
+			local newIndex = #Accounts[accountName] + 1
+			Accounts[accountName][newIndex] = CreateAddonAccount(accountName, accountRow.owner, accountRow.money)
+		else
+			if accountRow.money then
+				SharedAccounts[accountName] = CreateAddonAccount(accountName, nil, accountRow.money)
 			else
-				if account.money then
-					SharedAccounts[account.name] = CreateAddonAccount(account.name, nil, account.money)
-				else
-					newAccounts[#newAccounts + 1] = { account.name, 0 }
-				end
+				newAccounts[#newAccounts + 1] = { accountName, 0 }
 			end
-		end
-		GlobalState.SharedAccounts = SharedAccounts
-
-		if next(newAccounts) then
-			MySQL.prepare('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', newAccounts)
-			for i = 1, #newAccounts do
-				local newAccount = newAccounts[i]
-				SharedAccounts[newAccount[1]] = CreateAddonAccount(newAccount[1], nil, 0)
-			end
-			GlobalState.SharedAccounts = SharedAccounts
 		end
 	end
-end)
 
-function GetAccount(name, owner)
-	for i = 1, #Accounts[name], 1 do
-		if Accounts[name][i].owner == owner then
-			return Accounts[name][i]
+	GlobalState.SharedAccounts = SharedAccounts
+
+	if next(newAccounts) then
+		MySQL.prepare.await('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', newAccounts)
+
+		for _, newAccount in ipairs(newAccounts) do
+			local accountName = newAccount[1]
+			SharedAccounts[accountName] = CreateAddonAccount(accountName, nil, 0)
+		end
+
+		GlobalState.SharedAccounts = SharedAccounts
+	end
+end
+
+---@param name string
+---@param owner string
+---@return AddonAccount?
+local function getAccount(name, owner)
+	for _, account in ipairs(Accounts[name]) do
+		if account.owner == owner then
+			return account
 		end
 	end
 end
 
-function GetSharedAccount(name)
+---@param name string
+---@return AddonAccount
+local function getSharedAccount(name)
 	return SharedAccounts[name]
 end
 
-function AddSharedAccount(society, amount)
-	-- society.name = job_name/society_name
-	-- society.label = label for the job/account
-	-- amount = if the shared account should start with x amount
-	if type(society) ~= 'table' or not society?.name or not society?.label then return end
+---@param society { name: string, label: string }
+---@param amount? number
+---@return AddonAccount?
+local function addSharedAccount(society, amount)
+	local societyName, societyLabel = society?.name, society?.label
+	if not societyName or not societyLabel then return end
 
-	-- check if account already exist?
-	if SharedAccounts[society.name] ~= nil then return SharedAccounts[society.name] end
+	local existingSharedAccount = SharedAccounts[societyName]
+	if existingSharedAccount then return existingSharedAccount end
 
-	-- addon account:
-	local account = MySQL.insert.await('INSERT INTO `addon_account` (name, label, shared) VALUES (?, ?, ?)', {
-		society.name, society.label, 1
-	})
+	local account = MySQL.insert.await('INSERT INTO `addon_account` (name, label, shared) VALUES (?, ?, ?)', { societyName, societyLabel, 1 })
 	if not account then return end
 
-	-- if addon account inserted, insert addon account data:
-	local account_data = MySQL.insert.await('INSERT INTO `addon_account_data` (account_name, money) VALUES (?, ?)', {
-		society.name, (amount or 0)
+	amount = amount or 0
+	local accountData = MySQL.insert.await('INSERT INTO `addon_account_data` (account_name, money) VALUES (?, ?)', {
+		societyName, amount
 	})
-	if not account_data then return end
+	if not accountData then return end
 
-	-- if all data inserted successfully to sql:
-	SharedAccounts[society.name] = CreateAddonAccount(society.name, nil, (amount or 0))
+	SharedAccounts[societyName] = CreateAddonAccount(societyName, nil, amount)
 
-	return SharedAccounts[society.name]
+	GlobalState.SharedAccounts = SharedAccounts
+
+	return SharedAccounts[societyName]
 end
 
+AddEventHandler('onResourceStart', function(resourceName)
+	if resourceName ~= GetCurrentResourceName() then return end
+
+	initializeAccounts()
+end)
+
+---@param name string
+---@param owner string
+---@param cb function
 AddEventHandler('esx_addonaccount:getAccount', function(name, owner, cb)
-	cb(GetAccount(name, owner))
+	cb(getAccount(name, owner))
 end)
 
+---@param name string
+---@param cb function
 AddEventHandler('esx_addonaccount:getSharedAccount', function(name, cb)
-	cb(GetSharedAccount(name))
+	cb(getSharedAccount(name))
 end)
 
-AddEventHandler('esx:playerLoaded', function(playerId, xPlayer)
+AddEventHandler('esx:playerLoaded', function(_, xPlayer)
 	local addonAccounts = {}
 
-	for i = 1, #AccountsIndex, 1 do
-		local name    = AccountsIndex[i]
-		local account = GetAccount(name, xPlayer.identifier)
+	local identifier = xPlayer.getIdentifier()
+	for _, accountName in pairs(Accounts) do
+		local account = getAccount(accountName, identifier)
 
-		if account == nil then
-			MySQL.insert('INSERT INTO addon_account_data (account_name, money, owner) VALUES (?, ?, ?)',
-				{ name, 0, xPlayer.identifier })
+		if not account then
+			MySQL.insert.await('INSERT INTO addon_account_data (account_name, money, owner) VALUES (?, ?, ?)',
+				{ accountName, 0, identifier })
 
-			account = CreateAddonAccount(name, xPlayer.identifier, 0)
-			Accounts[name][#Accounts[name] + 1] = account
+			account = CreateAddonAccount(accountName, identifier, 0)
+
+			local newIndex = #Accounts[accountName] + 1
+			Accounts[accountName][newIndex] = account
 		end
 
 		addonAccounts[#addonAccounts + 1] = account
@@ -104,37 +128,8 @@ AddEventHandler('esx:playerLoaded', function(playerId, xPlayer)
 	xPlayer.set('addonAccounts', addonAccounts)
 end)
 
-RegisterNetEvent('esx_addonaccount:refreshAccounts')
-AddEventHandler('esx_addonaccount:refreshAccounts', function()
-	local addonAccounts = MySQL.query.await('SELECT * FROM addon_account')
+RegisterNetEvent('esx_addonaccount:refreshAccounts', initializeAccounts)
 
-	for i = 1, #addonAccounts, 1 do
-		local name             = addonAccounts[i].name
-		local shared           = addonAccounts[i].shared
-
-		local addonAccountData = MySQL.query.await('SELECT * FROM addon_account_data WHERE account_name = ?', { name })
-
-		if shared == 0 then
-			table.insert(AccountsIndex, name)
-			Accounts[name] = {}
-
-			for j = 1, #addonAccountData, 1 do
-				local addonAccount = CreateAddonAccount(name, addonAccountData[j].owner, addonAccountData[j].money)
-				table.insert(Accounts[name], addonAccount)
-			end
-		else
-			local money = nil
-
-			if #addonAccountData == 0 then
-				MySQL.insert('INSERT INTO addon_account_data (account_name, money, owner) VALUES (?, ?, ?)',
-					{ name, 0, nil })
-				money = 0
-			else
-				money = addonAccountData[1].money
-			end
-
-			local addonAccount   = CreateAddonAccount(name, nil, money)
-			SharedAccounts[name] = addonAccount
-		end
-	end
-end)
+exports('GetSharedAccount', getSharedAccount)
+exports('AddSharedAccount', addSharedAccount)
+exports('GetAccount', getAccount)

--- a/[esx_addons]/esx_addonaccount/server/main.lua
+++ b/[esx_addons]/esx_addonaccount/server/main.lua
@@ -162,6 +162,23 @@ AddEventHandler('esx_addonaccount:getSharedAccount', function(name, cb)
     cb(getSharedAccount(name))
 end)
 
+AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
+    if eventData.secondsRemaining == 60 then
+        CreateThread(function()
+            Wait(50000)
+            Database.saveAccounts()
+        end)
+    end
+end)
+
+AddEventHandler('onResourceStop', function(resource)
+    if resource == GetCurrentResourceName() then
+        Database.saveAccounts()
+    end
+end)
+
+AddEventHandler('txAdmin:events:serverShuttingDown', Database.saveAccounts)
+
 exports('GetSharedAccount', getSharedAccount)
 exports('GetAccount', getAccount)
 

--- a/[esx_addons]/esx_addonaccount/server/main.lua
+++ b/[esx_addons]/esx_addonaccount/server/main.lua
@@ -131,7 +131,7 @@ end
 
 ---@param accountData TransactionAccount
 ---@return AddonAccount?
-local function getTransactionAccount(accountData)
+function GetTransactionAccount(accountData)
     if type(accountData) == "string" then
         return getSharedAccount(accountData)
     end
@@ -148,7 +148,7 @@ end
 ---@param amount number
 ---@return boolean, string
 local function transferMoney(sender, receiver, amount)
-    local senderAccount, receiverAccount = getTransactionAccount(sender), getTransactionAccount(receiver)
+    local senderAccount, receiverAccount = GetTransactionAccount(sender), GetTransactionAccount(receiver)
     if not senderAccount or not receiverAccount then return false, 'invalid_account' end
 
     if not senderAccount.removeMoney(amount) then


### PR DESCRIPTION
### Description

This PR is a rewrite of esx_addonaccount while keeping compatibility.

---

### Motivation

Those changes where made to keep the code up to date and use newer stuff.

---

### Implementation Details

Added type annotations for the `AddonAccount` class.
Stored the accounts in a "simplified table", while keeping compatibility.
Registered the exports in the server/main.lua instead of the fxmanifest.
Added lazy loading for both account types.
Save accounts on restart and not at every transactions.
Added some exports.

---

### Usage Example

Added the following exports server-side:
`exports.esx_addonaccount:AddAccountMoney('property_black_money', xPlayer.getIdentifier(), 50)`
`exports.esx_addonaccount:RemoveAccountMoney('property_black_money', xPlayer.getIdentifier(), 50)`
`exports.esx_addonaccount:SetAccountMoney('property_black_money', xPlayer.getIdentifier(), 50)`
`exports.esx_addonaccount:AddSharedAccountMoney('society_police', 50)`
`exports.esx_addonaccount:RemoveSharedAccountMoney('society_police', 50)`
`exports.esx_addonaccount:SetSharedAccountMoney('society_police', 50)`

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
