### PR TITLE
Change version metadata key to 'legacyversion'

### DIFF
--- a/[esx_addons]/esx_hud/server/main.lua
+++ b/[esx_addons]/esx_hud/server/main.lua
@@ -27,7 +27,7 @@ end
 VERSION = {
     Check = function(err, response, headers)
         local resourceName = GetCurrentResourceName()
-        local currentVersion = GetResourceMetadata(resourceName, "legacyversion", 0)
+        local currentVersion = GetResourceMetadata(resourceName, "version", 0)
         if not currentVersion then return end
 
         local manifestURL = HUD.VersionCheckBaseURL .. resourceName .. "/fxmanifest.lua"
@@ -38,7 +38,7 @@ VERSION = {
             return
         end
 
-        local remoteVersion = response:match("version%s+'([%d%.]+)'")
+        local remoteVersion = response:match('version%s*["\']([%d%.]+)["\']')
         if not remoteVersion then
             HUD:ErrorHandle(Translate("errorGetRemoteVersion"))
             return

--- a/[esx_addons]/esx_hud/server/main.lua
+++ b/[esx_addons]/esx_hud/server/main.lua
@@ -27,7 +27,7 @@ end
 VERSION = {
     Check = function(err, response, headers)
         local resourceName = GetCurrentResourceName()
-        local currentVersion = GetResourceMetadata(resourceName, "version", 0)
+        local currentVersion = GetResourceMetadata(resourceName, "legacyversion", 0)
         if not currentVersion then return end
 
         local manifestURL = HUD.VersionCheckBaseURL .. resourceName .. "/fxmanifest.lua"


### PR DESCRIPTION
This way, we avoid the version checker error.
If you look at the “version” metadata in the fxmanifest, you will get an error because it is being compared with the latest version of the esx core. So we will look at the “legacyversion” metadata.

<img width="1304" height="482" alt="image" src="https://github.com/user-attachments/assets/06ad09d1-ec26-4b10-a2de-6ee0e22ed855" />
