### PR TITLE
fix: make conditional loop based on local `isDead` variable

### DIFF
--- a/[esx_addons]/esx_ambulancejob/client/main.lua
+++ b/[esx_addons]/esx_ambulancejob/client/main.lua
@@ -83,7 +83,7 @@ function OnPlayerDeath()
     FreezeEntityPosition(ESX.PlayerData.ped, true)
 
     Citizen.CreateThreadNow(function()
-      while ESX.PlayerData.dead do
+      while isDead do
         if not IsEntityPlayingAnim(ESX.PlayerData.ped, Config.DeathAnim.dict, Config.DeathAnim.name, 3) then
           TaskPlayAnim(ESX.PlayerData.ped, Config.DeathAnim.dict, Config.DeathAnim.name, Config.DeathAnim.fadeIn, Config.DeathAnim.fadeOut,
             -1, Config.DeathAnim.flags, Config.DeathAnim.playbackRate, false, false, false)


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->
Fixes the race condition in ambulance job. es_extended is setting ESX.PlayerData.dead in the same event. No waiting at all causes the conditional loop to not even start because ESX.PlayerData.dead is still false.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
Improving ESX

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->
Replacing the condition with a new one. (Existing local `isDead` variable)

---

### Usage Example

```lua
-- Add example usage here
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
