### PR TITLE
fix(esx_ambulancejob): restore persisted death state on reconnect

### DIFF
--- a/[esx_addons]/esx_ambulancejob/client/main.lua
+++ b/[esx_addons]/esx_ambulancejob/client/main.lua
@@ -6,6 +6,25 @@ AddEventHandler('esx:playerLoaded', function(xPlayer)
   ESX.PlayerLoaded = true
 end)
 
+RegisterNetEvent('esx_ambulancejob:restoreDeath')
+AddEventHandler('esx_ambulancejob:restoreDeath', function(elapsed)
+  CreateThread(function()
+    while not ESX.PlayerLoaded or not ESX.PlayerData.ped or not DoesEntityExist(ESX.PlayerData.ped) do
+      Wait(100)
+    end
+
+    local bleedoutLimit = ESX.Math.Round(Config.EarlyRespawnTimer / 1000) + ESX.Math.Round(Config.BleedoutTimer / 1000)
+
+    if elapsed and elapsed >= bleedoutLimit then
+      RemoveItemsAfterRPDeath()
+      return
+    end
+
+    ESX.SetPlayerData('dead', true)
+    OnPlayerDeath(elapsed)
+  end)
+end)
+
 RegisterNetEvent('esx:onPlayerLogout')
 AddEventHandler('esx:onPlayerLogout', function()
   ESX.PlayerLoaded = false
@@ -15,6 +34,7 @@ end)
 AddEventHandler('esx:onPlayerSpawn', function()
   if firstSpawn then
     firstSpawn = false
+    TriggerServerEvent('esx_ambulancejob:requestDeathRestore')
     return
   end
   isDead = false
@@ -59,7 +79,9 @@ AddEventHandler('esx_ambulancejob:clsearch', function(medicId)
   end
 end)
 
-function OnPlayerDeath()
+function OnPlayerDeath(elapsed)
+  if isDead then return end
+
   ESX.CloseContext()
   ClearTimecycleModifier()
   SetTimecycleModifier("REDMIST_blend")
@@ -68,7 +90,7 @@ function OnPlayerDeath()
   SetExtraTimecycleModifierStrength(1.0)
   SetPedMotionBlur(PlayerPedId(), true)
   TriggerServerEvent('esx_ambulancejob:setDeathStatus', true)
-  StartDeathTimer()
+  StartDeathTimer(elapsed)
   StartDeathCam()
   isDead = true
   StartDeathLoop() 
@@ -218,7 +240,9 @@ function secondsToClock(seconds)
   end
 end
 
-function StartDeathTimer()
+function StartDeathTimer(elapsed)
+  elapsed = elapsed or 0
+
   local canPayFine = false
 
   if Config.EarlyRespawnFine then
@@ -229,6 +253,15 @@ function StartDeathTimer()
 
   local earlySpawnTimer = ESX.Math.Round(Config.EarlyRespawnTimer / 1000)
   local bleedoutTimer = ESX.Math.Round(Config.BleedoutTimer / 1000)
+
+  if elapsed > 0 then
+    if elapsed >= earlySpawnTimer then
+      bleedoutTimer = bleedoutTimer - (elapsed - earlySpawnTimer)
+      earlySpawnTimer = 0
+    else
+      earlySpawnTimer = earlySpawnTimer - elapsed
+    end
+  end
 
   CreateThread(function()
     -- early respawn timer

--- a/[esx_addons]/esx_ambulancejob/client/main.lua
+++ b/[esx_addons]/esx_ambulancejob/client/main.lua
@@ -89,7 +89,6 @@ function OnPlayerDeath(elapsed)
   SetExtraTimecycleModifier("fp_vig_red")
   SetExtraTimecycleModifierStrength(1.0)
   SetPedMotionBlur(PlayerPedId(), true)
-  TriggerServerEvent('esx_ambulancejob:setDeathStatus', true)
   StartDeathTimer(elapsed)
   StartDeathCam()
   isDead = true
@@ -354,8 +353,6 @@ function GetClosestRespawnPoint()
 end
 
 function RemoveItemsAfterRPDeath()
-  TriggerServerEvent('esx_ambulancejob:setDeathStatus', false)
-
   CreateThread(function()
     ESX.TriggerServerCallback('esx_ambulancejob:removeItemsAfterRPDeath', function()
       local ClosestHospital = GetClosestRespawnPoint()
@@ -404,7 +401,6 @@ RegisterNetEvent('esx_ambulancejob:revive')
 AddEventHandler('esx_ambulancejob:revive', function()
   local playerPed = PlayerPedId()
   local coords = GetEntityCoords(playerPed)
-  TriggerServerEvent('esx_ambulancejob:setDeathStatus', false)
 
   DoScreenFadeOut(800)
 

--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -24,14 +24,8 @@ local function persistDeathStatus(src, bool)
 
 	if bool then
 		xPlayer.setMeta('deathTime', os.time())
-		xPlayer.setMeta('health', 0)
-	else
-		if xPlayer.getMeta().deathTime ~= nil then
-			xPlayer.clearMeta('deathTime')
-		end
-		if xPlayer.getMeta().health ~= nil then
-			xPlayer.clearMeta('health')
-		end
+	elseif xPlayer.getMeta().deathTime ~= nil then
+		xPlayer.clearMeta('deathTime')
 	end
 end
 
@@ -398,13 +392,10 @@ AddEventHandler('esx_ambulancejob:requestDeathRestore', function()
 		if isDead ~= true and isDead ~= 1 then return end
 		if deadPlayers[_source] then return end
 
-		local meta = xPlayer.getMeta()
-		if meta.health and meta.health > 0 then return end
-
 		deadPlayers[_source] = 'dead'
 		isDeadState(_source, true)
 
-		local deathTime = meta.deathTime
+		local deathTime = xPlayer.getMeta().deathTime
 		local elapsed = deathTime and (os.time() - deathTime) or 0
 		if elapsed < 0 then elapsed = 0 end
 

--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -24,8 +24,14 @@ local function persistDeathStatus(src, bool)
 
 	if bool then
 		xPlayer.setMeta('deathTime', os.time())
-	elseif xPlayer.getMeta().deathTime ~= nil then
-		xPlayer.clearMeta('deathTime')
+		xPlayer.setMeta('health', 0)
+	else
+		if xPlayer.getMeta().deathTime ~= nil then
+			xPlayer.clearMeta('deathTime')
+		end
+		if xPlayer.getMeta().health ~= nil then
+			xPlayer.clearMeta('health')
+		end
 	end
 end
 
@@ -87,9 +93,6 @@ RegisterNetEvent('esx:onPlayerDeath')
 AddEventHandler('esx:onPlayerDeath', function(data)
 	local source = source
 	if deadPlayers[source] then return end
-
-	local ped = GetPlayerPed(source)
-	if ped ~= 0 and GetEntityHealth(ped) > 0 then return end
 
 	deadPlayers[source] = 'dead'
 	local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
@@ -395,10 +398,13 @@ AddEventHandler('esx_ambulancejob:requestDeathRestore', function()
 		if isDead ~= true and isDead ~= 1 then return end
 		if deadPlayers[_source] then return end
 
+		local meta = xPlayer.getMeta()
+		if meta.health and meta.health > 0 then return end
+
 		deadPlayers[_source] = 'dead'
 		isDeadState(_source, true)
 
-		local deathTime = xPlayer.getMeta().deathTime
+		local deathTime = meta.deathTime
 		local elapsed = deathTime and (os.time() - deathTime) or 0
 		if elapsed < 0 then elapsed = 0 end
 

--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -15,6 +15,20 @@ local function isDeadState(src, bool)
 	Player(src).state:set('isDead', bool, true)
 end
 
+local function persistDeathStatus(src, bool)
+	local xPlayer = src and ESX.GetPlayerFromId(src)
+	if not xPlayer or type(bool) ~= 'boolean' then return end
+
+	MySQL.update('UPDATE users SET is_dead = ? WHERE identifier = ?', { bool, xPlayer.identifier })
+	isDeadState(src, bool)
+
+	if bool then
+		xPlayer.setMeta('deathTime', os.time())
+	elseif xPlayer.getMeta().deathTime ~= nil then
+		xPlayer.clearMeta('deathTime')
+	end
+end
+
 RegisterNetEvent('esx_ambulancejob:revive')
 AddEventHandler('esx_ambulancejob:revive', function(playerId)
 	playerId = tonumber(playerId)
@@ -71,9 +85,11 @@ end)
 RegisterNetEvent('esx:onPlayerDeath')
 AddEventHandler('esx:onPlayerDeath', function(data)
 	local source = source
+	if deadPlayers[source] then return end
+
 	deadPlayers[source] = 'dead'
 	local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
-	isDeadState(source, true)
+	persistDeathStatus(source, true)
 
 	for _, xPlayer in pairs(Ambulance) do
 		xPlayer.triggerEvent('esx_ambulancejob:PlayerDead', source)
@@ -354,10 +370,29 @@ ESX.RegisterServerCallback('esx_ambulancejob:getDeadPlayers', function(source, c
 	end
 end)
 
-ESX.RegisterServerCallback('esx_ambulancejob:getDeathStatus', function(source, cb)
-	local xPlayer = ESX.GetPlayerFromId(source)
+RegisterNetEvent('esx_ambulancejob:requestDeathRestore')
+AddEventHandler('esx_ambulancejob:requestDeathRestore', function()
+	local _source = source
+	local xPlayer = ESX.GetPlayerFromId(_source)
+	if not xPlayer then return end
+
 	MySQL.scalar('SELECT is_dead FROM users WHERE identifier = ?', { xPlayer.identifier }, function(isDead)
-		cb(isDead)
+		if isDead ~= true and isDead ~= 1 then return end
+		if deadPlayers[_source] then return end
+
+		deadPlayers[_source] = 'dead'
+		isDeadState(_source, true)
+
+		local deathTime = xPlayer.getMeta().deathTime
+		local elapsed = deathTime and (os.time() - deathTime) or 0
+		if elapsed < 0 then elapsed = 0 end
+
+		local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
+		for _, xAmbulance in pairs(Ambulance) do
+			xAmbulance.triggerEvent('esx_ambulancejob:PlayerDead', _source)
+		end
+
+		xPlayer.triggerEvent('esx_ambulancejob:restoreDeath', elapsed)
 	end)
 end)
 

--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -88,6 +88,9 @@ AddEventHandler('esx:onPlayerDeath', function(data)
 	local source = source
 	if deadPlayers[source] then return end
 
+	local ped = GetPlayerPed(source)
+	if ped ~= 0 and GetEntityHealth(ped) > 0 then return end
+
 	deadPlayers[source] = 'dead'
 	local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
 	persistDeathStatus(source, true)

--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -42,11 +42,11 @@ AddEventHandler('esx_ambulancejob:revive', function(playerId)
 					xPlayer.showNotification(TranslateCap('revive_complete_award', xTarget.name, Config.ReviveReward))
 					xPlayer.addMoney(Config.ReviveReward, "Revive Reward")
 					xTarget.triggerEvent('esx_ambulancejob:revive')
-					isDeadState(xTarget.source, false)
+					persistDeathStatus(xTarget.source, false)
 				else
 					xPlayer.showNotification(TranslateCap('revive_complete', xTarget.name))
 					xTarget.triggerEvent('esx_ambulancejob:revive')
-					isDeadState(xTarget.source, false)
+					persistDeathStatus(xTarget.source, false)
 				end
 				local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
 
@@ -70,6 +70,7 @@ AddEventHandler('txAdmin:events:healedPlayer', function(eventData)
 		return
 	end
 	if deadPlayers[eventData.id] then
+		persistDeathStatus(eventData.id, false)
 		TriggerClientEvent('esx_ambulancejob:revive', eventData.id)
 		local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
 
@@ -165,6 +166,11 @@ end)
 
 ESX.RegisterServerCallback('esx_ambulancejob:removeItemsAfterRPDeath', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(source)
+	if not xPlayer then return cb() end
+
+	if deadPlayers[source] then
+		persistDeathStatus(source, false)
+	end
 
 	if Config.OxInventory and Config.RemoveItemsAfterRPDeath then
 		exports.ox_inventory:ClearInventory(xPlayer.source)
@@ -328,12 +334,18 @@ AddEventHandler('esx_ambulancejob:giveItem', function(itemName, amount)
 end)
 
 ESX.RegisterCommand('revive', 'admin', function(xPlayer, args, showError)
+	persistDeathStatus(args.playerId.source, false)
+	deadPlayers[args.playerId.source] = nil
 	args.playerId.triggerEvent('esx_ambulancejob:revive')
 end, true, { help = TranslateCap('revive_help'), validate = true, arguments = {
 	{ name = 'playerId', help = 'The player id', type = 'player' }
 } })
 
 ESX.RegisterCommand('reviveall', "admin", function(xPlayer, args, showError)
+	for targetId in pairs(deadPlayers) do
+		persistDeathStatus(targetId, false)
+		deadPlayers[targetId] = nil
+	end
 	TriggerClientEvent('esx_ambulancejob:revive', -1)
 end, false)
 
@@ -394,22 +406,4 @@ AddEventHandler('esx_ambulancejob:requestDeathRestore', function()
 
 		xPlayer.triggerEvent('esx_ambulancejob:restoreDeath', elapsed)
 	end)
-end)
-
-RegisterNetEvent('esx_ambulancejob:setDeathStatus')
-AddEventHandler('esx_ambulancejob:setDeathStatus', function(isDead)
-	local xPlayer = ESX.GetPlayerFromId(source)
-
-	if type(isDead) == 'boolean' then
-		MySQL.update('UPDATE users SET is_dead = ? WHERE identifier = ?', { isDead, xPlayer.identifier })
-		isDeadState(source, isDead)
-			
-		if not isDead then
-			local Ambulance = ESX.GetExtendedPlayers("job", "ambulance")
-			for _, xPlayer in pairs(Ambulance) do
-				xPlayer.triggerEvent('esx_ambulancejob:PlayerNotDead', source)
-			end
-		end
-	end
-
 end)


### PR DESCRIPTION
## Description

A player who disconnects while dead respawns alive on reconnect. The death
state is persisted to `is_dead` but never read back at login, so it's lost.

This reads `is_dead` on the first `esx:onPlayerSpawn` after load and restores
the dead state. A server-side `deathTime` is stored on death so the bleedout
timer resumes from where it left off instead of resetting; if the window has
already elapsed, the forced respawn triggers immediately.

`is_dead` writes are centralized through a server-side path.

## Changes
- Restore the dead state on reconnect from `is_dead`
- Store `deathTime`, resume the bleedout timer with the elapsed offset
- Graceful fallback when `deathTime` is absent (no crash, timer starts full)
- Debounce the death flow against double entry
- Route `is_dead` writes server-side across the validated paths

## Testing
- Dead → disconnect → reconnect → stays dead
- Reconnect mid-bleedout → timer resumes
- Bleedout elapsed → forced respawn
- EMS revive / `/revive` / `/reviveall` / normal respawn unaffected
- Existing `is_dead = 1` rows without `deathTime` → no crash