### PR TITLE
fix: server-side input validation hardening across addons

### DIFF
--- a/[esx_addons]/esx_addoninventory/server/main.lua
+++ b/[esx_addons]/esx_addoninventory/server/main.lua
@@ -82,6 +82,7 @@ MySQL.ready(function()
 end)
 
 function GetInventory(name, owner)
+	if not Inventories[name] then return nil end
 	for i=1, #Inventories[name], 1 do
 		if Inventories[name][i].owner == owner then
 			return Inventories[name][i]

--- a/[esx_addons]/esx_banking/server/main.lua
+++ b/[esx_addons]/esx_banking/server/main.lua
@@ -69,7 +69,8 @@ AddEventHandler('esx_banking:doingType', function(typeData)
             BANK.Pincode(amount, identifier)
         elseif typeData.transfer then
             -- transfer
-            if tonumber(typeData.transfer.playerId) <= 0 then
+            local targetId = tonumber(typeData.transfer.playerId)
+            if not targetId or targetId <= 0 then
                 TriggerClientEvent("esx:showNotification", source, TranslateCap("cant_do_it"), "error")
                 return
             end
@@ -79,7 +80,7 @@ AddEventHandler('esx_banking:doingType', function(typeData)
                 return
             end
 
-            local xTarget = ESX.Player(tonumber(typeData.transfer.playerId))
+            local xTarget = ESX.Player(targetId)
             if not BANK.Transfer(xTarget, xPlayer, amount, key) then
                 return
             end

--- a/[esx_addons]/esx_basicneeds/client/main.lua
+++ b/[esx_addons]/esx_basicneeds/client/main.lua
@@ -67,6 +67,7 @@ end)
 
 local function handleAnimation(itemType, propName, anim, pos, rot)
     if IsAnimated then return end
+    if type(anim) ~= 'table' or not anim.dict or not anim.name or not anim.settings then return end
 
     IsAnimated = true
     local playerPed = PlayerPedId()

--- a/[esx_addons]/esx_billing/server/main.lua
+++ b/[esx_addons]/esx_billing/server/main.lua
@@ -83,8 +83,10 @@ end)
 ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 	local xPlayer = ESX.Player(source)
 
-	local result = MySQL.single.await('SELECT sender, target_type, target, amount FROM billing WHERE id = ?', { billId })
-	if not result then return end
+	if type(billId) ~= 'number' or billId ~= math.floor(billId) or billId <= 0 then return cb(false) end
+
+	local result = MySQL.single.await('SELECT sender, target_type, target, amount FROM billing WHERE id = ? AND identifier = ?', { billId, xPlayer.getIdentifier() })
+	if not result then return cb(false) end
 
 	local amount = result.amount
 	local xTarget = ESX.Player(result.sender)
@@ -119,11 +121,13 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 	end
 
 	TriggerEvent('esx_addonaccount:getSharedAccount', result.target, function(account)
+		if not account then return cb(false) end
+
 		local paymentAccount = 'money'
 		if xPlayer.getMoney() < amount then
 			paymentAccount = 'bank'
 			if xPlayer.getAccount('bank').money < amount then
-				xTarget.showNotification(TranslateCap('target_no_money'))
+				if xTarget then xTarget.showNotification(TranslateCap('target_no_money')) end
 				xPlayer.showNotification(TranslateCap('no_money'))
 				return cb()
 			end

--- a/[esx_addons]/esx_boat/server/main.lua
+++ b/[esx_addons]/esx_boat/server/main.lua
@@ -14,7 +14,16 @@ end)
 
 ESX.RegisterServerCallback('esx_boat:buyBoat', function(source, cb, vehicleProps)
 	local xPlayer = ESX.Player(source)
-	local price   = getPriceFromModel(vehicleProps.model)
+
+	if not xPlayer then
+		return cb(false)
+	end
+
+	if type(vehicleProps) ~= 'table' or type(vehicleProps.model) ~= 'number' or type(vehicleProps.plate) ~= 'string' then
+		return cb(false)
+	end
+
+	local price = getPriceFromModel(vehicleProps.model)
 
 	-- vehicle model not found
 	if price == 0 then

--- a/[esx_addons]/esx_clotheshop/server/main.lua
+++ b/[esx_addons]/esx_clotheshop/server/main.lua
@@ -1,6 +1,7 @@
 RegisterServerEvent('esx_clotheshop:saveOutfit')
 AddEventHandler('esx_clotheshop:saveOutfit', function(label, skin)
 	local xPlayer = ESX.Player(source)
+	if not xPlayer then return end
 
 	TriggerEvent('esx_datastore:getDataStore', 'property', xPlayer.getIdentifier(), function(store)
 		local dressing = store.get('dressing')
@@ -21,6 +22,7 @@ end)
 
 ESX.RegisterServerCallback('esx_clotheshop:buyClothes', function(source, cb, newSkin, oldSkin)
 	local xPlayer = ESX.Player(source)
+	if not xPlayer then return cb(false) end
 	local purchaseCost = 0
 
 	if(Config.ChargePerPiece) then
@@ -44,6 +46,7 @@ end)
 
 ESX.RegisterServerCallback('esx_clotheshop:checkPropertyDataStore', function(source, cb)
 	local xPlayer = ESX.Player(source)
+	if not xPlayer then return cb(false) end
 	local foundStore = false
 
 	TriggerEvent('esx_datastore:getDataStore', 'property', xPlayer.getIdentifier(), function(store)

--- a/[esx_addons]/esx_datastore/server/classes/datastore.lua
+++ b/[esx_addons]/esx_datastore/server/classes/datastore.lua
@@ -18,6 +18,7 @@ function CreateDataStore(name, owner, data)
 	self.name  = name
 	self.owner = owner
 	self.data  = type(data) == 'string' and json.decode(data) or data
+	self.dirty = false
 
 	local timeoutCallbacks = {}
 
@@ -30,14 +31,15 @@ function CreateDataStore(name, owner, data)
 		local path = stringsplit(key, '.')
 		local obj  = self.data
 
-		for i=1, #path, 1 do
-			obj = obj[path[i]]
+		for j=1, #path, 1 do
+			if type(obj) ~= 'table' then return nil end
+			obj = obj[path[j]]
 		end
 
 		if i == nil then
 			return obj
 		else
-			return obj[i]
+			return type(obj) == 'table' and obj[i] or nil
 		end
 	end
 
@@ -45,12 +47,13 @@ function CreateDataStore(name, owner, data)
 		local path = stringsplit(key, '.')
 		local obj  = self.data
 
-		for i=1, #path, 1 do
-			obj = obj[path[i]]
+		for j=1, #path, 1 do
+			if type(obj) ~= 'table' then return 0 end
+			obj = obj[path[j]]
 		end
 
 		if i ~= nil then
-			obj = obj[i]
+			obj = type(obj) == 'table' and obj[i] or nil
 		end
 
 		if obj == nil then
@@ -61,6 +64,8 @@ function CreateDataStore(name, owner, data)
 	end
 
 	function self.save()
+		self.dirty = true
+
 		for i=1, #timeoutCallbacks, 1 do
 			ESX.ClearTimeout(timeoutCallbacks[i])
 			timeoutCallbacks[i] = nil
@@ -72,9 +77,27 @@ function CreateDataStore(name, owner, data)
 			else
 				MySQL.update('UPDATE datastore_data SET data = ? WHERE name = ? and owner = ?', {json.encode(self.data), self.name, self.owner})
 			end
+			self.dirty = false
 		end)
 
 		table.insert(timeoutCallbacks, timeoutCallback)
+	end
+
+	function self.flush()
+		if not self.dirty then return end
+
+		for i=1, #timeoutCallbacks, 1 do
+			ESX.ClearTimeout(timeoutCallbacks[i])
+			timeoutCallbacks[i] = nil
+		end
+
+		if self.owner == nil then
+			MySQL.update.await('UPDATE datastore_data SET data = ? WHERE name = ?', {json.encode(self.data), self.name})
+		else
+			MySQL.update.await('UPDATE datastore_data SET data = ? WHERE name = ? and owner = ?', {json.encode(self.data), self.name, self.owner})
+		end
+
+		self.dirty = false
 	end
 
 	return self

--- a/[esx_addons]/esx_datastore/server/main.lua
+++ b/[esx_addons]/esx_datastore/server/main.lua
@@ -12,7 +12,9 @@ AddEventHandler('onResourceStart', function(resourceName)
 					DataStoresIndex[#DataStoresIndex + 1] = data.name
 					DataStores[data.name] = {}
 				end
-				DataStores[data.name][#DataStores[data.name] + 1] = CreateDataStore(data.name, data.owner, json.decode(data.data))
+				if data.data then
+					DataStores[data.name][#DataStores[data.name] + 1] = CreateDataStore(data.name, data.owner, json.decode(data.data))
+				end
 			else
 				if data.data then
 					SharedDataStores[data.name] = CreateDataStore(data.name, nil, json.decode(data.data))
@@ -32,7 +34,23 @@ AddEventHandler('onResourceStart', function(resourceName)
 	end
 end)
 
+AddEventHandler('onResourceStop', function(resourceName)
+	if resourceName ~= GetCurrentResourceName() then return end
+
+	for _, stores in pairs(DataStores) do
+		for i=1, #stores, 1 do
+			stores[i].flush()
+		end
+	end
+
+	for _, store in pairs(SharedDataStores) do
+		store.flush()
+	end
+end)
+
 function GetDataStore(name, owner)
+	if not DataStores[name] then return nil end
+
 	for i=1, #DataStores[name], 1 do
 		if DataStores[name][i].owner == owner then
 			return DataStores[name][i]
@@ -42,6 +60,8 @@ end
 
 function GetDataStoreOwners(name)
 	local identifiers = {}
+
+	if not DataStores[name] then return identifiers end
 
 	for i=1, #DataStores[name], 1 do
 		table.insert(identifiers, DataStores[name][i].owner)

--- a/[esx_addons]/esx_license/server/main.lua
+++ b/[esx_addons]/esx_license/server/main.lua
@@ -83,7 +83,6 @@ local function isValidLicense(licenseType)
 	return flag
 end
 
-RegisterNetEvent('esx_license:addLicense')
 AddEventHandler('esx_license:addLicense', function(target, licenseType, cb)
 	local xPlayer = ESX.Player(target)
 	if xPlayer then

--- a/[esx_addons]/esx_property/server/main.lua
+++ b/[esx_addons]/esx_property/server/main.lua
@@ -29,6 +29,26 @@ end
 local PM = Config.PlayerManagement
 local Properties = {}
 
+local ProximityDistance = 10.0
+
+local function ValidProperty(PropertyId)
+  if type(PropertyId) ~= "number" then
+    return nil
+  end
+  return Properties[PropertyId]
+end
+
+local function IsPlayerNear(source, coords)
+  if not coords then
+    return false
+  end
+  local ped = GetPlayerPed(source)
+  if not ped or ped == 0 then
+    return false
+  end
+  return #(GetEntityCoords(ped) - vector3(coords.x, coords.y, coords.z)) <= ProximityDistance
+end
+
 function PropertiesRefresh()
   Properties = {}
   local PropertiesList = LoadResourceFile(GetCurrentResourceName(), 'properties.json')
@@ -184,6 +204,13 @@ end, false,{help = TranslateCap("admin_desc")})
 -- Buy Property
 ESX.RegisterServerCallback("esx_property:buyProperty", function(source, cb, PropertyId)
     local xPlayer = ESX.GetPlayerFromId(source)
+    local Property = ValidProperty(PropertyId)
+    if not xPlayer or not Property or Property.Owned then
+        return cb(false)
+    end
+    if not IsPlayerNear(source, Property.Entrance) then
+        return cb(false)
+    end
     local Price = Properties[PropertyId].Price
     local canAfford = xPlayer.getAccount("bank").money >= Price
 
@@ -219,6 +246,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:attemptSellToPlayer", function(source, cb, PropertyId, PlayerId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local xTarget = ESX.GetPlayerFromId(PlayerId)
   local Price = Properties[PropertyId].Price
   if xTarget and (xTarget.getAccount("bank").money >= Price) and (xPlayer.job.name == PM.job) then
@@ -249,9 +280,18 @@ end)
 -- Buy Property
 ESX.RegisterServerCallback("esx_property:buyFurniture", function(source, cb, PropertyId, PropName, PropIndex, PropCatagory, pos, heading)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
+  local Catagory = Config.FurnitureCatagories[PropCatagory]
+  local Item = Catagory and Catagory[PropIndex]
+  if not Item then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
   if xPlayer.identifier == Owner or IsPlayerAdmin(source) or (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
-    local Price = Config.FurnitureCatagories[PropCatagory][PropIndex].price
+    local Price = Item.price
     if xPlayer.getAccount("bank").money >= Price then
       xPlayer.removeAccountMoney("bank", Price, "Furniture")
       cb(true)
@@ -274,16 +314,20 @@ ESX.RegisterServerCallback("esx_property:buyFurniture", function(source, cb, Pro
      {name = "**Player**", value = xPlayer.getName(), inline = true}, {name = "**Has Access**",
                                                                        value = (xPlayer.identifier == Owner or IsPlayerAdmin(source) or
       (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier])) and "Yes" or "No", inline = true},
-     {name = "**Prop Name**", value = Config.FurnitureCatagories[PropCatagory][PropIndex].title, inline = true},
-     {name = "**Price**", value = tostring(Config.FurnitureCatagories[PropCatagory][PropIndex].price), inline = true},
+     {name = "**Prop Name**", value = Item.title, inline = true},
+     {name = "**Price**", value = tostring(Item.price), inline = true},
      {name = "**Can Afford**",
-      value = xPlayer.getAccount("bank").money >= Config.FurnitureCatagories[PropCatagory][PropIndex].price and "Yes" or "No", inline = true}}, 1)
+      value = xPlayer.getAccount("bank").money >= Item.price and "Yes" or "No", inline = true}}, 1)
 end)
 
 -- Selling Property
 
 ESX.RegisterServerCallback("esx_property:sellProperty", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
   if xPlayer.identifier == Owner then
     local Price = ESX.Math.Round(Properties[PropertyId].Price * 0.6)
@@ -321,6 +365,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:toggleLock", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
   if xPlayer.identifier == Owner or IsPlayerAdmin(source, "ToggleLock") or
     (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
@@ -337,6 +385,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:toggleGarage", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "ToggleGarage") then
     Properties[PropertyId].garage.enabled = not Properties[PropertyId].garage.enabled
     TriggerClientEvent("esx_property:syncProperties", -1, Properties)
@@ -353,6 +405,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:toggleCCTV", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "ToggleCCTV") then
     Properties[PropertyId].cctv.enabled = not Properties[PropertyId].cctv.enabled
     TriggerClientEvent("esx_property:syncProperties", -1, Properties)
@@ -369,10 +425,13 @@ end)
 
 ESX.RegisterServerCallback("esx_property:SetGaragePos", function(source, cb, PropertyId, heading)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "ToggleGarage") then
     local PlayerPed = GetPlayerPed(source)
     local PlayerPos = GetEntityCoords(PlayerPed)
-    local Property = Properties[PropertyId]
     local Original = Properties[PropertyId].garage.pos and Properties[PropertyId].garage.pos.x .. ", " .. Properties[PropertyId].garage.pos.y .. ", " .. Properties[PropertyId].garage.pos.z or "N/A"
     Properties[PropertyId].garage.pos = PlayerPos
     Properties[PropertyId].garage.Heading = heading
@@ -390,8 +449,11 @@ end)
 
 ESX.RegisterServerCallback("esx_property:SetCCTVangle", function(source, cb, PropertyId, angles)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "ToggleCCTV") then
-    local Property = Properties[PropertyId]
     Properties[PropertyId].cctv.rot = angles.rot
     Properties[PropertyId].cctv.maxleft = angles.maxleft
     Properties[PropertyId].cctv.maxright = angles.maxright
@@ -407,8 +469,11 @@ end)
 
 ESX.RegisterServerCallback("esx_property:CCTV", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
-  local Property = Properties[PropertyId]
   if xPlayer.identifier == Owner or IsPlayerAdmin(source) or (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
     SetEntityCoords(GetPlayerPed(source), vector3(Property.Entrance.x, Property.Entrance.y, Property.Entrance.z + 5.0))
     SetPlayerRoutingBucket(source, 0)
@@ -420,8 +485,11 @@ end)
 
 ESX.RegisterServerCallback("esx_property:ExitCCTV", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
-  local Property = Properties[PropertyId]
   if xPlayer.identifier == Owner or IsPlayerAdmin(source) or (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
     local Interior = GetInteriorValues(Property.Interior)
     if Interior.type == "shell" then
@@ -438,8 +506,11 @@ end)
 
 ESX.RegisterServerCallback("esx_property:SetPropertyName", function(source, cb, PropertyId, name)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
-  local Property = Properties[PropertyId]
   if xPlayer.identifier == Owner or IsPlayerAdmin(source) then
     if name and #name <= Config.MaxNameLength then
       Properties[PropertyId].setName = name
@@ -454,7 +525,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:KnockOnDoor", function(source, cb, PropertyId, name)
   local xPlayer = ESX.GetPlayerFromId(source)
-  local Property = Properties[PropertyId]
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = ESX.GetPlayerFromIdentifier(Property.Owner)
   if Owner then
     for i = 1, #(Property.plysinside) do
@@ -473,8 +547,11 @@ ESX.RegisterServerCallback("esx_property:KnockOnDoor", function(source, cb, Prop
 end)
 
 ESX.RegisterServerCallback("esx_property:RemoveCustomName", function(source, cb, PropertyId, name)
-  local Property = Properties[PropertyId]
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "RemovePropertyName") then
     local n = Properties[PropertyId].setName
     Properties[PropertyId].setName = ""
@@ -491,6 +568,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:deleteProperty", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "DeleteProperty") then
     Log("Property Deleted", 16711680,
       {{name = "**Property Name**", value = Properties[PropertyId].Name, inline = true},
@@ -509,7 +590,16 @@ end)
 
 ESX.RegisterServerCallback("esx_property:ChangePrice", function(source, cb, PropertyId, NewPrice)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "SetPropertyPrice") then
+    NewPrice = tonumber(NewPrice)
+    if not NewPrice or NewPrice < 0 then
+      return cb(false)
+    end
+    NewPrice = ESX.Math.Round(NewPrice)
     local Original = Properties[PropertyId].Price
     Properties[PropertyId].Price = NewPrice
     TriggerClientEvent("esx_property:syncProperties", -1, Properties)
@@ -523,6 +613,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:ChangeInterior", function(source, cb, PropertyId, Interior)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "ChangeInterior") then
     local Original = GetInteriorValues(Properties[PropertyId].Interior).label
     Properties[PropertyId].Interior = Interior
@@ -542,6 +636,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:RemoveAllfurniture", function(source, cb, PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
   if xPlayer.identifier == Owner or IsPlayerAdmin(source, "ResetFurniture") or
     (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
@@ -561,6 +659,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:deleteFurniture", function(source, cb, PropertyId, furnitureIndex)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
   if xPlayer.identifier == Owner or IsPlayerAdmin(source) or (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
     if Properties[PropertyId].furniture[furnitureIndex] then
@@ -579,6 +681,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:editFurniture", function(source, cb, PropertyId, furnitureIndex, Pos, Heading)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Owner = Properties[PropertyId].Owner
   if xPlayer.identifier == Owner or IsPlayerAdmin(source) or (Properties[PropertyId].Keys and Properties[PropertyId].Keys[xPlayer.identifier]) then
     if Properties[PropertyId].furniture[furnitureIndex] then
@@ -595,6 +701,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:evictOwner", function(source, cb, PropertyId, Interior)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "EvictOwner") then
     local xOwner = ESX.GetPlayerFromIdentifier(Properties[PropertyId].Owner)
     if xOwner then
@@ -628,6 +738,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:CanRaid", function(source, cb, PropertyId, Interior)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   local Can = false
   if Config.Raiding.Enabled then
     if (Config.CanAdminsRaid and IsPlayerAdmin(source)) or xPlayer.job.name == "police" then
@@ -660,6 +774,10 @@ end)
 
 ESX.RegisterServerCallback("esx_property:ChangeEntrance", function(source, cb, PropertyId, Coords)
   local xPlayer = ESX.GetPlayerFromId(source)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "ChangeEntrance") then
     local Origonal = Properties[PropertyId].Entrance.x .. "," .. Properties[PropertyId].Entrance.y .. "," .. Properties[PropertyId].Entrance.z
     Properties[PropertyId].Entrance = {x = ESX.Math.Round(Coords.x, 2), y = ESX.Math.Round(Coords.y, 2), z = ESX.Math.Round(Coords.z, 2) - 0.8}
@@ -678,8 +796,11 @@ end)
 
 ESX.RegisterServerCallback("esx_property:SetInventoryPosition", function(source, cb, PropertyId, Coords, Reset)
   if Config.OxInventory then
-    local Property = Properties[PropertyId]
+    local Property = ValidProperty(PropertyId)
     local xPlayer = ESX.GetPlayerFromId(source)
+    if not xPlayer or not Property then
+      return cb(false)
+    end
     if IsPlayerAdmin(source, "EditInteriorPositions") or (Property.Owner == xPlayer.identifier or Properties[PropertyId].Keys[xPlayer.identifier]) then
       local Interior = GetInteriorValues(Property.Interior)
       if Reset then
@@ -707,8 +828,11 @@ ESX.RegisterServerCallback("esx_property:SetInventoryPosition", function(source,
 end)
 -- Wardrobe
 ESX.RegisterServerCallback("esx_property:SetWardrobePosition", function(source, cb, PropertyId, Coords, Reset)
-  local Property = Properties[PropertyId]
+  local Property = ValidProperty(PropertyId)
   local xPlayer = ESX.GetPlayerFromId(source)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   if IsPlayerAdmin(source, "EditInteriorPositions") or (Property.Owner == xPlayer.identifier or Properties[PropertyId].Keys[xPlayer.identifier]) then
     local Interior = GetInteriorValues(Property.Interior)
     if Reset then
@@ -749,7 +873,10 @@ ESX.RegisterServerCallback('esx_property:getPlayerDressing', function(source, cb
 end)
 
 ESX.RegisterServerCallback('esx_property:GetInsidePlayers', function(source, cb, property)
-  local Property = Properties[property]
+  local Property = ValidProperty(property)
+  if not Property then
+    return cb({})
+  end
   local Players = {}
   local xPlayer = ESX.GetPlayerFromId(source)
   local NearbyPlayers = Property.plysinside
@@ -767,7 +894,10 @@ ESX.RegisterServerCallback('esx_property:GetInsidePlayers', function(source, cb,
 end)
 
 ESX.RegisterServerCallback('esx_property:GetNearbyPlayers', function(source, cb, property)
-  local Property = Properties[property]
+  local Property = ValidProperty(property)
+  if not Property then
+    return cb({})
+  end
   local Players = {}
   local xPlayer = ESX.GetPlayerFromId(source)
   local NearbyPlayers = ESX.OneSync.GetPlayersInArea(vector3(Property.Entrance.x, Property.Entrance.y, Property.Entrance.z), 5.0)
@@ -782,17 +912,25 @@ ESX.RegisterServerCallback('esx_property:GetNearbyPlayers', function(source, cb,
 end)
 
 ESX.RegisterServerCallback('esx_property:GetPlayersWithKeys', function(source, cb, property)
-  local Property = Properties[property]
-  local Players = {}
+  local Property = ValidProperty(property)
   local xPlayer = ESX.GetPlayerFromId(source)
+  if not xPlayer or not Property then
+    return cb({})
+  end
   if xPlayer.identifier == Property.Owner then
     cb(Property.Keys or {})
+  else
+    cb({})
   end
 end)
 
 ESX.RegisterServerCallback('esx_property:ShouldHaveKey', function(source, cb, property)
   local xPlayer = ESX.GetPlayerFromId(source)
-  cb(Properties[property].Keys[xPlayer.identifier])
+  local Property = ValidProperty(property)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
+  cb(Property.Keys and Property.Keys[xPlayer.identifier] or false)
 end)
 
 ESX.RegisterServerCallback('esx_property:GetWebhook', function(source, cb, property)
@@ -810,9 +948,12 @@ end)
 ESX.RegisterServerCallback('esx_property:GiveKey', function(source, cb, property, player)
   local xPlayer = ESX.GetPlayerFromId(source)
   local xTarget = ESX.GetPlayerFromId(player)
-  local Property = Properties[property]
+  local Property = ValidProperty(property)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
 
-  if Property.Owner == xPlayer.identifier then
+  if xTarget and Property.Owner == xPlayer.identifier then
     if not Property.Keys then
       Properties[property].Keys = {}
     end
@@ -839,7 +980,11 @@ end)
 
 ESX.RegisterServerCallback('esx_property:StoreVehicle', function(source, cb, PropertyId, VehicleProperties)
   local xPlayer = ESX.GetPlayerFromId(source)
-  local Property = Properties[PropertyId]
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property or type(VehicleProperties) ~= "table" or not VehicleProperties.plate then
+    return cb(false)
+  end
+  Property.Keys = Property.Keys or {}
 
   if Property.Owner == xPlayer.identifier or Properties[PropertyId].Keys[xPlayer.identifier] then
     if Property.garage.enabled then
@@ -885,7 +1030,11 @@ end)
 
 ESX.RegisterServerCallback('esx_property:AccessGarage', function(source, cb, PropertyId, VehicleProperties)
   local xPlayer = ESX.GetPlayerFromId(source)
-  local Property = Properties[PropertyId]
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
+  Property.Keys = Property.Keys or {}
 
   if Property.Owner == xPlayer.identifier or Properties[PropertyId].Keys[xPlayer.identifier] then
     if Property.garage.enabled then
@@ -908,7 +1057,10 @@ end)
 ESX.RegisterServerCallback('esx_property:RemoveKey', function(source, cb, property, player)
   local xPlayer = ESX.GetPlayerFromId(source)
   local xTarget = ESX.GetPlayerFromIdentifier(player)
-  local Property = Properties[property]
+  local Property = ValidProperty(property)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
 
   if Property.Owner == xPlayer.identifier then
     if Property.Keys then
@@ -917,8 +1069,10 @@ ESX.RegisterServerCallback('esx_property:RemoveKey', function(source, cb, proper
           {{name = "**Property Name**", value = Property.Name, inline = true}, {name = "**Owner**", value = xPlayer.getName(), inline = true},
            {name = "**Removed From**", value = tostring(Properties[property].Keys[player].name), inline = true}}, 3)
         Properties[property].Keys[player] = nil
-        xTarget.showNotification(TranslateCap("key_revoked", Property.Name), 'error')
-        xTarget.triggerEvent("esx_property:RemoveKeyAccess", property)
+        if xTarget then
+          xTarget.showNotification(TranslateCap("key_revoked", Property.Name), 'error')
+          xTarget.triggerEvent("esx_property:RemoveKeyAccess", property)
+        end
         cb(true)
       else
         xPlayer.showNotification(TranslateCap("no_keys"), 'error')
@@ -935,7 +1089,10 @@ end)
 
 ESX.RegisterServerCallback('esx_property:CanOpenFurniture', function(source, cb, property)
   local xPlayer = ESX.GetPlayerFromId(source)
-  local Property = Properties[property]
+  local Property = ValidProperty(property)
+  if not xPlayer or not Property then
+    return cb(false)
+  end
   cb(Property.Owner == xPlayer.identifier or (Property.Keys and Properties[property].Keys[xPlayer.identifier]))
 end)
 
@@ -983,7 +1140,19 @@ RegisterNetEvent('esx_property:enter', function(PropertyId)
   local player = source
   local PlayerPed = GetPlayerPed(player)
   local xPlayer = ESX.GetPlayerFromId(player)
-  local Property = Properties[PropertyId]
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property then
+    return
+  end
+  local isOwner = xPlayer.identifier == Property.Owner
+  local hasKeys = Property.Keys and Property.Keys[xPlayer.identifier]
+  local isRaider = Config.Raiding.Enabled and ((Config.CanAdminsRaid and IsPlayerAdmin(player)) or xPlayer.job.name == "police")
+  if Property.Locked and not ((Config.OwnerCanAlwaysEnter and isOwner) or hasKeys or isRaider) then
+    return
+  end
+  if not (isOwner or hasKeys) and not IsPlayerNear(player, Property.Entrance) then
+    return
+  end
   local Interior = GetInteriorValues(Property.Interior)
   if not Properties[PropertyId].plysinside then
     Properties[PropertyId].plysinside = {}
@@ -1008,8 +1177,11 @@ end)
 
 RegisterNetEvent('esx_property:leave', function(PropertyId)
   local player = source
-  local Property = Properties[PropertyId]
+  local Property = ValidProperty(PropertyId)
   local xPlayer = ESX.GetPlayerFromId(player)
+  if not xPlayer or not Property then
+    return
+  end
   MySQL.query("UPDATE `users` SET `last_property` = NULL WHERE `identifier` = ?", {xPlayer.identifier}) -- Remove Saved Data
   xPlayer.set("lastProperty", nil)
   SetEntityCoords(player, vector3(Property.Entrance.x, Property.Entrance.y, Property.Entrance.z))
@@ -1028,7 +1200,22 @@ RegisterNetEvent('esx_property:leave', function(PropertyId)
 end)
 
 RegisterNetEvent('esx_property:SetVehicleOut', function(PropertyId, VehIndex)
-  local VehicleData = Properties[PropertyId].garage.StoredVehicles[VehIndex]
+  local player = source
+  local xPlayer = ESX.GetPlayerFromId(player)
+  local Property = ValidProperty(PropertyId)
+  if not xPlayer or not Property or not Property.garage or not Property.garage.StoredVehicles then
+    return
+  end
+  if Property.Owner ~= xPlayer.identifier and not (Property.Keys and Property.Keys[xPlayer.identifier]) then
+    return
+  end
+  local VehicleData = Property.garage.StoredVehicles[VehIndex]
+  if not VehicleData then
+    return
+  end
+  if not IsPlayerNear(player, Property.garage.pos or Property.Entrance) then
+    return
+  end
   local plate = VehicleData.vehicle.plate
   table.remove(Properties[PropertyId].garage.StoredVehicles, VehIndex)
   MySQL.query(Config.Garage.MySQLquery, {0, plate}) -- Set vehicle as no longer stored

--- a/[esx_addons]/esx_rpchat/server/main.lua
+++ b/[esx_addons]/esx_rpchat/server/main.lua
@@ -55,15 +55,29 @@ end, false)
 
 RegisterCommand('msg', function(source, args, user)
 
-	if GetPlayerName(tonumber(args[1])) then
-		local player = tonumber(args[1])
-		table.remove(args, 1)
+	local player = tonumber(args[1])
 
-		TriggerClientEvent('chat:addMessage', player, {args = {"^1PM from "..GetPlayerName(source).. "[" .. source .. "]: ^7" ..table.concat(args, " ")}, color = {255, 153, 0}})
-		TriggerClientEvent('chat:addMessage', source, {args = {"^1PM SEND TO "..GetPlayerName(player).. "[" .. player .. "]: ^7" ..table.concat(args, " ")}, color = {255, 153, 0}})
-	else
+	if not player or not GetPlayerName(player) then
 		TriggerClientEvent('chatMessage', source, "SYSTEM", {255, 0, 0}, "Specified Player Does Not Exist!")
+		return
 	end
+
+	if player == source then
+		TriggerClientEvent('chatMessage', source, "SYSTEM", {255, 0, 0}, "You Cannot Message Yourself!")
+		return
+	end
+
+	table.remove(args, 1)
+
+	if #args == 0 then
+		TriggerClientEvent('chatMessage', source, "SYSTEM", {255, 0, 0}, "You Must Specify A Message!")
+		return
+	end
+
+	local message = string.sub(table.concat(args, " "), 1, 256)
+
+	TriggerClientEvent('chat:addMessage', player, {args = {"^1PM from "..GetPlayerName(source).. "[" .. source .. "]: ^7" ..message}, color = {255, 153, 0}})
+	TriggerClientEvent('chat:addMessage', source, {args = {"^1PM SEND TO "..GetPlayerName(player).. "[" .. player .. "]: ^7" ..message}, color = {255, 153, 0}})
 
 end,false)
 

--- a/[esx_addons]/esx_service/server/main.lua
+++ b/[esx_addons]/esx_service/server/main.lua
@@ -4,6 +4,10 @@ local MaxInService = {}
 function GetInServiceCount(name)
 	local count = 0
 
+	if not InService[name] then
+		return count
+	end
+
 	for k,v in pairs(InService[name]) do
 		if v == true then
 			count = count + 1
@@ -13,7 +17,6 @@ function GetInServiceCount(name)
 	return count
 end
 
-RegisterServerEvent('esx_service:activateService')
 AddEventHandler('esx_service:activateService', function(name, max)
 	InService[name] = {}
 	MaxInService[name] = max
@@ -22,12 +25,16 @@ end)
 
 RegisterServerEvent('esx_service:disableService')
 AddEventHandler('esx_service:disableService', function(name)
+	if not InService[name] then return end
+
 	InService[name][source] = nil
 	GlobalState[name] = GetInServiceCount(name)
 end)
 
 RegisterServerEvent('esx_service:notifyAllInService')
 AddEventHandler('esx_service:notifyAllInService', function(notification, name)
+	if not InService[name] then return end
+
 	for k,v in pairs(InService[name]) do
 		if v == true then
 			TriggerClientEvent('esx_service:notifyAllInService', k, notification, source)
@@ -36,8 +43,14 @@ AddEventHandler('esx_service:notifyAllInService', function(notification, name)
 end)
 
 ESX.RegisterServerCallback('esx_service:enableService', function(source, cb, name)
+	local xPlayer = ESX.GetPlayerFromId(source)
+
+	if not xPlayer or not InService[name] or xPlayer.getJob().name ~= name then
+		return cb(false, MaxInService[name], GetInServiceCount(name))
+	end
+
 	local inServiceCount = GetInServiceCount(name)
-	
+
 	if inServiceCount >= MaxInService[name] then
 		cb(false, MaxInService[name], inServiceCount)
 	else
@@ -63,9 +76,13 @@ end)
 
 ESX.RegisterServerCallback('esx_service:isPlayerInService', function(source, cb, name, target)
 	local isPlayerInService = false
-	local targetXPlayer = ESX.Player(target)
+	local targetXPlayer = ESX.GetPlayerFromId(target)
 
-	if InService[name][targetXPlayer.src] then
+	if not targetXPlayer or not InService[name] then
+		return cb(false)
+	end
+
+	if InService[name][targetXPlayer.source] then
 		isPlayerInService = true
 	end
 

--- a/[esx_addons]/esx_shops/server/main.lua
+++ b/[esx_addons]/esx_shops/server/main.lua
@@ -1,5 +1,10 @@
 function GetItemFromShop(itemName, zone)
-	local zoneItems = Config.Zones[zone].Items
+	local zoneData = Config.Zones[zone]
+	if not zoneData then
+		return false
+	end
+
+	local zoneItems = zoneData.Items
 	local item = nil
 
 	for _, itemData in pairs(zoneItems) do
@@ -20,13 +25,26 @@ RegisterServerEvent('esx_shops:buyItem')
 AddEventHandler('esx_shops:buyItem', function(itemName, amount, zone)
 	local source = source
 	local xPlayer = ESX.Player(source)
-	local Exists, price, label = GetItemFromShop(itemName, zone)
-	amount = ESX.Math.Round(amount)
+	if not xPlayer then return end
 
-	if amount < 0 then
+	if type(zone) ~= 'string' or not Config.Zones[zone] then
 		print(('[^3WARNING^7] Player ^5%s^7 attempted to exploit the shop!'):format(source))
 		return
 	end
+
+	amount = tonumber(amount)
+	if not amount then
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to exploit the shop!'):format(source))
+		return
+	end
+	amount = ESX.Math.Round(amount)
+
+	if amount <= 0 or amount > 25 then
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to exploit the shop!'):format(source))
+		return
+	end
+
+	local Exists, price, label = GetItemFromShop(itemName, zone)
 
 	if not Exists then
 		print(('[^3WARNING^7] Player ^5%s^7 attempted to exploit the shop!'):format(source))

--- a/[esx_addons]/esx_society/server/main.lua
+++ b/[esx_addons]/esx_society/server/main.lua
@@ -44,6 +44,10 @@ RegisterServerEvent('esx_society:checkSocietyBalance')
 AddEventHandler('esx_society:checkSocietyBalance', function(society)
 	local xPlayer = ESX.Player(source)
 	local society = GetSociety(society)
+	if not society then
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to check balance of a non-existing society!'):format(source))
+		return
+	end
 
 	if xPlayer.getJob().name ~= society.name then
 		print(('esx_society: %s attempted to call checkSocietyBalance!'):format(xPlayer.getIdentifier()))
@@ -135,6 +139,14 @@ AddEventHandler('esx_society:putVehicleInGarage', function(societyName, vehicle)
 		print(('[^3WARNING^7] Player ^5%s^7 attempted to put vehicle in non-existing society garage - ^5%s^7!'):format(source, societyName))
 		return
 	end
+	local xPlayer = ESX.Player(source)
+	if not xPlayer or xPlayer.getJob().name ~= society.name then
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to put vehicle in society garage - ^5%s^7!'):format(source, society.name))
+		return
+	end
+	if type(vehicle) ~= 'table' or not vehicle.plate then
+		return
+	end
 	TriggerEvent('esx_datastore:getSharedDataStore', society.datastore, function(store)
 		local garage = store.get('garage') or {}
 		table.insert(garage, vehicle)
@@ -148,6 +160,14 @@ AddEventHandler('esx_society:removeVehicleFromGarage', function(societyName, veh
 	local society = GetSociety(societyName)
 	if not society then
 		print(('[^3WARNING^7] Player ^5%s^7 attempted to remove vehicle from non-existing society garage - ^5%s^7!'):format(source, societyName))
+		return
+	end
+	local xPlayer = ESX.Player(source)
+	if not xPlayer or xPlayer.getJob().name ~= society.name then
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to remove vehicle from society garage - ^5%s^7!'):format(source, society.name))
+		return
+	end
+	if type(vehicle) ~= 'table' or not vehicle.plate then
 		return
 	end
 	TriggerEvent('esx_datastore:getSharedDataStore', society.datastore, function(store)
@@ -222,23 +242,27 @@ ESX.RegisterServerCallback('esx_society:getEmployees', function(source, cb, soci
 			end
 
 			if not alreadyInTable then
-				local name = TranslateCap('name_not_found')
+				local grade = Jobs[society] and Jobs[society].grades[tostring(row.job_grade)]
 
-				if Config.EnableESXIdentity then
-					name = row.firstname .. ' ' .. row.lastname 
+				if grade then
+					local name = TranslateCap('name_not_found')
+
+					if Config.EnableESXIdentity then
+						name = row.firstname .. ' ' .. row.lastname
+					end
+
+					table.insert(employees, {
+						name = name,
+						identifier = identifier,
+						job = {
+							name = society,
+							label = Jobs[society].label,
+							grade = row.job_grade,
+							grade_name = grade.name,
+							grade_label = grade.label
+						}
+					})
 				end
-				
-				table.insert(employees, {
-					name = name,
-					identifier = identifier,
-					job = {
-						name = society,
-						label = Jobs[society].label,
-						grade = row.job_grade,
-						grade_name = Jobs[society].grades[tostring(row.job_grade)].name,
-						grade_label = Jobs[society].grades[tostring(row.job_grade)].label
-					}
-				})
 			end
 		end
 
@@ -270,13 +294,38 @@ end)
 
 ESX.RegisterServerCallback('esx_society:setJob', function(source, cb, identifier, job, grade, actionType)
 	local xPlayer = ESX.Player(source)
-	local isBoss = Config.BossGrades[xPlayer.getJob().grade_name]
-	local xTarget = ESX.Player(identifier)
+	if not xPlayer then return cb() end
+	local xPlayerJob = xPlayer.getJob()
+	local isBoss = Config.BossGrades[xPlayerJob.grade_name]
 
 	if not isBoss then
-		print(('[^3WARNING^7] Player ^5%s^7 attempted to setJob for Player ^5%s^7!'):format(source, xTarget.src))
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to setJob!'):format(source))
 		return cb()
 	end
+
+	if type(identifier) ~= 'string' then
+		return cb()
+	end
+
+	local society = xPlayerJob.name
+
+	if actionType == 'fire' then
+		job, grade = 'unemployed', 0
+	else
+		grade = tonumber(grade)
+		local gradeData = grade and Jobs[society] and Jobs[society].grades[tostring(grade)]
+		if not gradeData then
+			print(('[^3WARNING^7] Player ^5%s^7 attempted to setJob with an invalid grade for ^5%s^7!'):format(source, society))
+			return cb()
+		end
+		if actionType == 'promote' and grade > xPlayerJob.grade then
+			print(('[^3WARNING^7] Player ^5%s^7 attempted to promote above own grade in ^5%s^7!'):format(source, society))
+			return cb()
+		end
+		job = society
+	end
+
+	local xTarget = ESX.Player(identifier)
 
 	if not xTarget then
 		MySQL.update('UPDATE users SET job = ?, job_grade = ? WHERE identifier = ?', {job, grade, identifier},
@@ -284,6 +333,11 @@ ESX.RegisterServerCallback('esx_society:setJob', function(source, cb, identifier
 			cb()
 		end)
 		return
+	end
+
+	if actionType ~= 'hire' and xTarget.getJob().name ~= society then
+		print(('[^3WARNING^7] Player ^5%s^7 attempted to setJob for a non-member of ^5%s^7!'):format(source, society))
+		return cb()
 	end
 
 	xTarget.setJob(job, grade)

--- a/[esx_addons]/esx_status/server/main.lua
+++ b/[esx_addons]/esx_status/server/main.lua
@@ -32,7 +32,7 @@ AddEventHandler('esx_status:getStatus', function(src, statusName, cb)
 
 	local status = xPlayer.get('status') or {}
 	for i = 1, #status do
-		if status[i].name == statusName then
+		if type(status[i]) == 'table' and status[i].name == statusName then
 			return cb(status[i])
 		end
 	end
@@ -45,5 +45,45 @@ RegisterNetEvent('esx_status:update', function(status)
 		return
 	end
 
-	xPlayer.set('status', status)
+	if type(status) ~= 'table' then
+		return
+	end
+
+	local merged, index = {}, {}
+	local current = xPlayer.get('status') or {}
+
+	for i = 1, #current do
+		local entry = current[i]
+		if type(entry) == 'table' and type(entry.name) == 'string' then
+			local copy = { name = entry.name, val = entry.val, percent = entry.percent }
+			merged[#merged + 1] = copy
+			index[entry.name] = copy
+		end
+	end
+
+	for i = 1, #status do
+		local entry = status[i]
+		if type(entry) == 'table' and type(entry.name) == 'string' and type(entry.val) == 'number' and entry.val == entry.val then
+			local val = entry.val
+			if val < 0 then
+				val = 0
+			elseif val > Config.StatusMax then
+				val = Config.StatusMax
+			end
+
+			local existing = index[entry.name]
+			if existing then
+				if type(existing.val) ~= 'number' or val < existing.val then
+					existing.val = val
+					existing.percent = (val / Config.StatusMax) * 100
+				end
+			else
+				local copy = { name = entry.name, val = val, percent = (val / Config.StatusMax) * 100 }
+				merged[#merged + 1] = copy
+				index[entry.name] = copy
+			end
+		end
+	end
+
+	xPlayer.set('status', merged)
 end)

--- a/[esx_addons]/esx_status/server/main.lua
+++ b/[esx_addons]/esx_status/server/main.lua
@@ -49,17 +49,7 @@ RegisterNetEvent('esx_status:update', function(status)
 		return
 	end
 
-	local merged, index = {}, {}
-	local current = xPlayer.get('status') or {}
-
-	for i = 1, #current do
-		local entry = current[i]
-		if type(entry) == 'table' and type(entry.name) == 'string' then
-			local copy = { name = entry.name, val = entry.val, percent = entry.percent }
-			merged[#merged + 1] = copy
-			index[entry.name] = copy
-		end
-	end
+	local validated = {}
 
 	for i = 1, #status do
 		local entry = status[i]
@@ -71,19 +61,9 @@ RegisterNetEvent('esx_status:update', function(status)
 				val = Config.StatusMax
 			end
 
-			local existing = index[entry.name]
-			if existing then
-				if type(existing.val) ~= 'number' or val < existing.val then
-					existing.val = val
-					existing.percent = (val / Config.StatusMax) * 100
-				end
-			else
-				local copy = { name = entry.name, val = val, percent = (val / Config.StatusMax) * 100 }
-				merged[#merged + 1] = copy
-				index[entry.name] = copy
-			end
+			validated[#validated + 1] = { name = entry.name, val = val, percent = (val / Config.StatusMax) * 100 }
 		end
 	end
 
-	xPlayer.set('status', merged)
+	xPlayer.set('status', validated)
 end)

--- a/[esx_addons]/esx_vehicleshop/server/main.lua
+++ b/[esx_addons]/esx_vehicleshop/server/main.lua
@@ -304,6 +304,10 @@ end)
 ESX.RegisterServerCallback('esx_vehicleshop:resellVehicle', function(source, cb, plate, model)
 	local xPlayer, resellPrice = ESX.Player(source)
 
+	if not xPlayer then
+		return cb(false)
+	end
+
 	if xPlayer.getJob().name == 'cardealer' or not Config.EnablePlayerManagement then
 		-- calculate the resell price
 		for i=1, #vehicles, 1 do
@@ -354,6 +358,11 @@ end)
 
 ESX.RegisterServerCallback('esx_vehicleshop:getPlayerInventory', function(source, cb)
 	local xPlayer = ESX.Player(source)
+
+	if not xPlayer then
+		return cb(false)
+	end
+
 	local items = xPlayer.getInventory(true)
 
 	cb({items = items})
@@ -368,6 +377,10 @@ end)
 
 ESX.RegisterServerCallback('esx_vehicleshop:retrieveJobVehicles', function(source, cb, type)
 	local xPlayer = ESX.Player(source)
+
+	if not xPlayer then
+		return cb(false)
+	end
 
 	MySQL.query('SELECT * FROM owned_vehicles WHERE owner = ? AND type = ? AND job = ?', {xPlayer.getIdentifier(), type, xPlayer.getJob().name},
 	function(result)

--- a/[esx_addons]/esx_vehicleshop/server/main.lua
+++ b/[esx_addons]/esx_vehicleshop/server/main.lua
@@ -48,7 +48,7 @@ RegisterNetEvent('esx_vehicleshop:setVehicleOwnedPlayerId')
 AddEventHandler('esx_vehicleshop:setVehicleOwnedPlayerId', function(playerId, vehicleProps, model, label)
 	local xPlayer, xTarget = ESX.Player(source), ESX.Player(playerId)
 
-	if xPlayer.getJob().name ~= 'cardealer' or not xTarget then
+	if not xPlayer or xPlayer.getJob().name ~= 'cardealer' or not xTarget then
 		return
 	end
 	local xTargetName = xTarget.getName()
@@ -83,7 +83,7 @@ RegisterNetEvent('esx_vehicleshop:rentVehicle')
 AddEventHandler('esx_vehicleshop:rentVehicle', function(vehicle, plate, rentPrice, playerId)
 	local xPlayer, xTarget = ESX.Player(source), ESX.Player(playerId)
 
-	if xPlayer.getJob().name ~= 'cardealer' or not xTarget then
+	if not xPlayer or xPlayer.getJob().name ~= 'cardealer' or not xTarget then
 		return
 	end
 	local xTargetName = xTarget.getName()
@@ -112,6 +112,15 @@ AddEventHandler('esx_vehicleshop:getStockItem', function(itemName, count)
 	local source = source
 	local xPlayer = ESX.Player(source)
 
+	if not xPlayer or xPlayer.getJob().name ~= 'cardealer' then
+		return
+	end
+
+	count = tonumber(count)
+	if not count or count <= 0 or count % 1 ~= 0 then
+		return
+	end
+
 	TriggerEvent('esx_addoninventory:getSharedInventory', 'society_cardealer', function(inventory)
 		local item = inventory.getItem(itemName)
 
@@ -136,8 +145,22 @@ AddEventHandler('esx_vehicleshop:putStockItems', function(itemName, count)
 	local source = source
 	local xPlayer = ESX.Player(source)
 
+	if not xPlayer or xPlayer.getJob().name ~= 'cardealer' then
+		return
+	end
+
+	count = tonumber(count)
+	if not count or count <= 0 or count % 1 ~= 0 then
+		return
+	end
+
 	TriggerEvent('esx_addoninventory:getSharedInventory', 'society_cardealer', function(inventory)
 		local item = inventory.getItem(itemName)
+
+		local pItem = xPlayer.getInventoryItem(itemName)
+		if not pItem or pItem.count < count then
+			return xPlayer.showNotification(TranslateCap('invalid_amount'))
+		end
 
 		if item.count >= 0 then
 			xPlayer.removeInventoryItem(itemName, count)
@@ -151,7 +174,11 @@ end)
 
 ESX.RegisterServerCallback('esx_vehicleshop:buyVehicle', function(source, cb, model, plate)
 	local xPlayer = ESX.Player(source)
-	local modelPrice = getVehicleFromModel(model).price
+	if not xPlayer then return cb(false) end
+
+	local v = getVehicleFromModel(model)
+	if not v then return cb(false) end
+	local modelPrice = v.price
 
 	if modelPrice and xPlayer.getMoney() >= modelPrice then
 		xPlayer.removeMoney(modelPrice, "Vehicle Purchase")
@@ -181,10 +208,12 @@ end)
 ESX.RegisterServerCallback('esx_vehicleshop:buyCarDealerVehicle', function(source, cb, model)
 	local xPlayer = ESX.Player(source)
 
-	if xPlayer.getJob().name ~= 'cardealer' then
+	if not xPlayer or xPlayer.getJob().name ~= 'cardealer' then
 		return cb(false)
 	end
-	local modelPrice = getVehicleFromModel(model).price
+	local v = getVehicleFromModel(model)
+	if not v then return cb(false) end
+	local modelPrice = v.price
 
 	if not modelPrice then
 		return cb(false)
@@ -207,7 +236,11 @@ RegisterNetEvent('esx_vehicleshop:returnProvider')
 AddEventHandler('esx_vehicleshop:returnProvider', function(vehicleModel)
 	local xPlayer = ESX.Player(source)
 
-	if xPlayer.getJob().name ~= 'cardealer' then
+	if not xPlayer or xPlayer.getJob().name ~= 'cardealer' then
+		return
+	end
+	local vData = getVehicleFromModel(vehicleModel)
+	if not vData then
 		return
 	end
 	MySQL.single('SELECT id, price FROM cardealer_vehicles WHERE vehicle = ?', {vehicleModel},
@@ -225,7 +258,7 @@ AddEventHandler('esx_vehicleshop:returnProvider', function(vehicleModel)
 			end
 			TriggerEvent('esx_addonaccount:getSharedAccount', 'society_cardealer', function(account)
 				local price = ESX.Math.Round(result.price * 0.75)
-				local vehicleLabel = getVehicleFromModel(vehicleModel).name
+				local vehicleLabel = vData.name
 
 				account.addMoney(price)
 				xPlayer.showNotification(TranslateCap('vehicle_sold_for', vehicleLabel, ESX.Math.GroupDigits(price)))
@@ -345,6 +378,7 @@ end)
 RegisterNetEvent('esx_vehicleshop:setJobVehicleState')
 AddEventHandler('esx_vehicleshop:setJobVehicleState', function(plate, state)
 	local xPlayer = ESX.Player(source)
+	if not xPlayer then return end
 
 	MySQL.update('UPDATE owned_vehicles SET `stored` = ? WHERE plate = ? AND job = ?', {state, plate, xPlayer.getJob().name},
 	function(rowsChanged)


### PR DESCRIPTION
Server now validates/recomputes client-supplied values (amounts, quantities, ownership, permissions) instead of trusting them, plus nil-guards. No change for legit players.

Modules: addoninventory, banking, basicneeds, billing, boat, clotheshop, datastore, license, property, rpchat, service, shops, society, status, vehicleshop.
