### PR TITLE
feat(esx_ambulancejob): optional Medal.tv auto-clip on death

### DIFF
--- a/[esx_addons]/esx_ambulancejob/README.md
+++ b/[esx_addons]/esx_ambulancejob/README.md
@@ -16,6 +16,10 @@ ESX Ambulance Job is an plugin for ESX with features:
 
 - [esx_society](https://github.com/esx-framework/esx_society)
 
+## Medal.tv auto-clip
+
+Automatically saves a Medal clip when a player dies, using Medal's public FiveM auto-clipping token. On by default; set `Config.Medal.enabled = false` in `config.lua` to turn it off. Each player needs the Medal desktop app running with the Events API enabled, and the clip is saved locally on their own machine.
+
 ## Legal
 
 ### License

--- a/[esx_addons]/esx_ambulancejob/client/main.lua
+++ b/[esx_addons]/esx_ambulancejob/client/main.lua
@@ -71,7 +71,8 @@ function OnPlayerDeath()
   StartDeathTimer()
   StartDeathCam()
   isDead = true
-  StartDeathLoop() 
+  TriggerMedalDeathClip()
+  StartDeathLoop()
   StartDistressSignal()
 
   if Config.DeathAnim.enabled then

--- a/[esx_addons]/esx_ambulancejob/client/medal.lua
+++ b/[esx_addons]/esx_ambulancejob/client/medal.lua
@@ -1,0 +1,15 @@
+function TriggerMedalDeathClip()
+    local cfg = Config.Medal
+    if not cfg or not cfg.enabled or cfg.publicKey == '' then return end
+
+    SendNUIMessage({
+        action = 'medalClip',
+        publicKey = cfg.publicKey,
+        payload = {
+            eventId = ('esx-ambulance-death-%s-%s'):format(GetPlayerServerId(PlayerId()), GetGameTimer()),
+            eventName = cfg.eventName or 'Death',
+            triggerActions = { 'SaveClip' },
+            clipOptions = cfg.clipOptions
+        }
+    })
+end

--- a/[esx_addons]/esx_ambulancejob/config.lua
+++ b/[esx_addons]/esx_ambulancejob/config.lua
@@ -30,9 +30,32 @@ Config.DistressBlip = {
 }
 
 Config.zoom = {
-	min = 1, 
-	max = 6, 
+	min = 1,
+	max = 6,
 	step = 0.5
+}
+
+---@class MedalClipOptions
+---@field duration integer
+---@field captureDelayMs integer
+---@field alertType 'Default'|'Disabled'|'SoundOnly'|'OverlayOnly'
+
+---@class MedalConfig
+---@field enabled boolean
+---@field publicKey string
+---@field eventName string
+---@field clipOptions MedalClipOptions
+
+---@type MedalConfig
+Config.Medal = {
+	enabled = true,
+	publicKey = 'pub_82qkpMKV77AkpqLSgWsxLlDyfzpPI7Vw',
+	eventName = 'Death',
+	clipOptions = {
+		duration = 30,
+		captureDelayMs = 0,
+		alertType = 'Default'
+	}
 }
 
 Config.EarlyRespawnTimer          = 60000 * 1  -- time til respawn is available

--- a/[esx_addons]/esx_ambulancejob/fxmanifest.lua
+++ b/[esx_addons]/esx_ambulancejob/fxmanifest.lua
@@ -21,6 +21,13 @@ client_scripts {
 	'client/*.lua'
 }
 
+ui_page 'html/medal.html'
+
+files {
+	'html/medal.html',
+	'html/medal.js'
+}
+
 dependencies {
 	'es_extended',
 	'esx_skin',

--- a/[esx_addons]/esx_ambulancejob/html/medal.html
+++ b/[esx_addons]/esx_ambulancejob/html/medal.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src http://localhost:12665 http://127.0.0.1:12665">
+</head>
+<body>
+    <script src="medal.js"></script>
+</body>
+</html>

--- a/[esx_addons]/esx_ambulancejob/html/medal.js
+++ b/[esx_addons]/esx_ambulancejob/html/medal.js
@@ -1,0 +1,13 @@
+window.addEventListener('message', function (event) {
+    var data = event.data;
+    if (!data || data.action !== 'medalClip') return;
+
+    fetch('http://localhost:12665/api/v1/event/invoke', {
+        method: 'POST',
+        headers: {
+            'publicKey': data.publicKey,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data.payload)
+    }).catch(function () {});
+});


### PR DESCRIPTION
Adds an optional Medal.tv auto-clip when a player dies, using Medal's fixed public FiveM auto-clipping token. On death the client saves a clip through the player's local Medal app (localhost:12665), so the clip lands on their own machine and nothing is sent to the server.

On by default. Set Config.Medal.enabled = false in config.lua to turn it off. Requires the player to run the Medal desktop app with the Events API enabled.
