### PR TITLE
fix(esx_society): check the shared account before moving money

### DIFF
--- a/[esx_addons]/esx_society/server/main.lua
+++ b/[esx_addons]/esx_society/server/main.lua
@@ -70,6 +70,10 @@ AddEventHandler('esx_society:withdrawMoney', function(societyName, amount)
 	end
 
 	TriggerEvent('esx_addonaccount:getSharedAccount', society.account, function(account)
+		if not account then
+			return print(('[^3WARNING^7] Society ^5%s^7 has no shared account!'):format(society.name))
+		end
+
 		if amount > 0 and account.money >= amount then
 			account.removeMoney(amount)
 			xPlayer.addMoney(amount, TranslateCap('money_add_reason'))
@@ -96,6 +100,10 @@ AddEventHandler('esx_society:depositMoney', function(societyName, amount)
 	end
 	if amount > 0 and xPlayer.getMoney() >= amount then
 		TriggerEvent('esx_addonaccount:getSharedAccount', society.account, function(account)
+			if not account then
+				return print(('[^3WARNING^7] Society ^5%s^7 has no shared account!'):format(society.name))
+			end
+
 			xPlayer.removeMoney(amount, TranslateCap('money_remove_reason'))
 			xPlayer.showNotification(TranslateCap('have_deposited', ESX.Math.GroupDigits(amount)))
 			account.addMoney(amount)
@@ -410,20 +418,28 @@ function WashMoneyCRON(d, h, m)
 	MySQL.query('SELECT * FROM society_moneywash', function(result)
 		for i=1, #result, 1 do
 			local society = GetSociety(result[i].society)
-			local xPlayer = ESX.Player(result[i].identifier)
 
-			-- add society money
-			TriggerEvent('esx_addonaccount:getSharedAccount', society.account, function(account)
-				account.addMoney(result[i].amount)
-			end)
+			if not society then
+				print(('[^3WARNING^7] Money wash pending for non-existing society - ^5%s^7!'):format(result[i].society))
+			else
+				local xPlayer = ESX.Player(result[i].identifier)
 
-			-- send notification if player is online
-			if xPlayer then
-				xPlayer.showNotification(TranslateCap('you_have_laundered', ESX.Math.GroupDigits(result[i].amount)))
+				-- add society money
+				TriggerEvent('esx_addonaccount:getSharedAccount', society.account, function(account)
+					if not account then
+						return print(('[^3WARNING^7] Society ^5%s^7 has no shared account!'):format(society.name))
+					end
+
+					account.addMoney(result[i].amount)
+					MySQL.update('DELETE FROM society_moneywash WHERE id = ?', {result[i].id})
+
+					-- send notification if player is online
+					if xPlayer then
+						xPlayer.showNotification(TranslateCap('you_have_laundered', ESX.Math.GroupDigits(result[i].amount)))
+					end
+				end)
 			end
-
 		end
-		MySQL.update('DELETE FROM society_moneywash')
 	end)
 end
 


### PR DESCRIPTION
### Description

`esx_society` uses the shared account handed to it by `esx_addonaccount` without checking that it exists. `GetSharedAccount` just returns `SharedAccounts[name]`, so a society that is registered but has no `addon_account` row gets `nil`, and the callback runs anyway.

Two places pay for that: `depositMoney` destroys the money, and `WashMoneyCRON` pays it out again every night.

---

### Motivation

**Deposits.** `depositMoney` takes the cash first and touches the account second:

```lua
xPlayer.removeMoney(amount, TranslateCap('money_remove_reason'))
xPlayer.showNotification(TranslateCap('have_deposited', ...))
account.addMoney(amount)
```

With no account the third line throws, and the money is gone. The player has already been told it worked.

`withdrawMoney` in the same file reads `account.money` before it changes anything, so it throws harmlessly. Same file, opposite order.

| deposit 1000 with no society account | before | after |
| --- | --- | --- |
| handler completes | no, `attempt to index a nil value (local 'account')` | yes |
| player cash | 4000 → 3000 | 4000 |

**Money washing.** `WashMoneyCRON` reads every pending row, credits each one, and deletes the whole table afterwards:

```lua
for i=1, #result, 1 do
    local society = GetSociety(result[i].society)
    ...
    TriggerEvent('esx_addonaccount:getSharedAccount', society.account, function(account)
        account.addMoney(result[i].amount)
    end)
    ...
end
MySQL.update('DELETE FROM society_moneywash')
```

One row belonging to a society that is no longer registered throws on `society.account`. That takes the query callback with it, so the `DELETE` never runs, and everything credited before it stays pending. Next night the same rows are credited again.

Three nights with one bad row among three, 6000 actually deposited:

| | before | after |
| --- | --- | --- |
| night 1 | 5000 credited, 3 rows still pending | 6000 credited, 1 row pending |
| night 2 | 10000 credited, 3 rows still pending | 6000, unchanged |
| night 3 | 15000 credited, 3 rows still pending | 6000, unchanged |

The third row (1000) never gets paid out at all, because the loop dies on the second one.

The `DELETE` also has no `WHERE`. Anything inserted between the `SELECT` and the callback is wiped without ever being credited.

---

### Implementation Details

A guard in both callbacks, using the warning style already in the file:

```lua
if not account then
    return print(('[^3WARNING^7] Society ^5%s^7 has no shared account!'):format(society.name))
end
```

In `WashMoneyCRON` the missing society is skipped with a warning instead of throwing, and each row is deleted by its own id once it has actually been credited. `society_moneywash` has `id` as an auto increment primary key, so that works without a schema change. The blanket `DELETE` is gone, which also closes the window on rows inserted mid-run.

Checked by loading the real handlers out of the file under Lua 5.4 and driving them, 15 assertions on the deposit and withdraw path and 8 on the cron. Before: 12/15 and 5/8. After: 15/15 and 8/8, with the normal paths unchanged.

Not tested on a live server. The deposit case needs a society registered by a job resource whose `addon_account` row was never inserted, the cron case needs a pending wash row for a society that has since been removed.

---

### Usage Example

```lua
-- job resource registers a society, its addon_account row was never inserted
TriggerServerEvent('esx_society:depositMoney', 'cardealer', 1000)
-- before: 1000 gone from the player, nothing credited, "you have deposited 1000"
-- after:  nothing happens, warning in the console
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
