### PR TITLE
fix(esx_banking): pass the transaction type when logging a received transfer

### DIFF
--- a/[esx_addons]/esx_banking/server/main.lua
+++ b/[esx_addons]/esx_banking/server/main.lua
@@ -207,7 +207,7 @@ BANK = {
         xPlayer.removeAccountMoney('bank', amount)
         xTarget.addAccountMoney('bank', amount)
         local bankMoney = xTarget.getAccount('bank').money
-        BANK.LogTransaction(xTarget.src, "TRANSFER_RECEIVE", amount, bankMoney)
+        BANK.LogTransaction(xTarget.src, "TRANSFER_RECEIVE", "TRANSFER_RECEIVE", amount, bankMoney)
         TriggerClientEvent("esx:showNotification", xTarget.src, TranslateCap('receive_transfer', amount, xPlayer.src),
             "success")
 


### PR DESCRIPTION
### Description

`BANK.LogTransaction` takes five parameters. The call in `BANK.Transfer` passes four, so everything after the label shifts one place to the left and the received transfer is written to `banking` with the wrong columns.

---

### Motivation

```lua
LogTransaction = function(playerId, label, logType, amount, bankMoney)
```

```lua
BANK.LogTransaction(xTarget.src, "TRANSFER_RECEIVE", amount, bankMoney)
```

The other two call sites in the same file pass all five. Only this one is short.

Transferring 500 to a player whose balance ends up at 600 writes:

| column | before | after |
| --- | --- | --- |
| `label` | `TRANSFER_RECEIVE` | `TRANSFER_RECEIVE` |
| `type` | `500` (number) | `TRANSFER_RECEIVE` |
| `amount` | `600`, the balance | `500` |
| `balance` | `NULL` | `600` |

`banking.balance` is nullable with a default, so the row is written without complaint.

The receiving player sees the result in the UI. `app.js` switches on `trans.type`, and a number matches no case, so it falls through to `default: trans.type = languageText.transfer`. The render then checks `type == withdraw || type == transfer` and draws the row as money going out. So an incoming transfer shows up as an outgoing one, for the wrong amount, with an empty balance column and a gap in the history graph.

Verified by loading the real `BANK` table out of the file under Lua 5.4 and calling `Transfer`, then comparing against `LogTransaction` called the way the deposit path calls it. 4/8 before, 8/8 after.

---

### Implementation Details

```lua
-BANK.LogTransaction(xTarget.src, "TRANSFER_RECEIVE", amount, bankMoney)
+BANK.LogTransaction(xTarget.src, "TRANSFER_RECEIVE", "TRANSFER_RECEIVE", amount, bankMoney)
```

Label and type carry the same value here, which is what the withdraw path at line 100 does as well (`string.upper(key)` twice).

Existing rows written by the old call keep their shifted values. This only fixes new ones, and I would rather not touch anyone's transaction history in a bug fix.

Not tested on a live server.

---

### Usage Example

```lua
-- player A transfers 500 to player B, B ends up with 600 in the bank
-- before: B's history shows "Transfer  -600" with no balance
-- after:  B's history shows "Transfer received  500", balance 600
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
