### PR TITLE
fix(esx_vehicleshop): evict the rental that breaks an offline renter's budget

### DIFF
--- a/[esx_addons]/esx_vehicleshop/server/main.lua
+++ b/[esx_addons]/esx_vehicleshop/server/main.lua
@@ -412,6 +412,7 @@ function PayRent()
 							if sum > accounts.bank then
 								sum = sum - rental.rent_price
 								limit = true
+								unrentals[#unrentals + 1] = {rental.owner, rental.plate}
 							end
 						else
 							unrentals[#unrentals + 1] = {rental.owner, rental.plate}


### PR DESCRIPTION
### Description

When an offline renter cannot pay for all of their rentals, `PayRent` walks the list and evicts the ones it cannot cover. The rental that actually breaks the budget is taken back out of the running total but never added to `unrentals`, so it is neither paid for nor cancelled.

---

### Motivation

```lua
if not limit then
    sum = sum + rental.rent_price
    if sum > accounts.bank then
        sum = sum - rental.rent_price
        limit = true
    end
else
    unrentals[#unrentals + 1] = {rental.owner, rental.plate}
end
```

Only the rentals after the limit get evicted. The one that hit it stays.

The online branch a few lines above does it properly, evicting every rental it cannot afford, so the two paths disagree about what happens to the same rental.

Three rentals at 500 each, 600 in the bank, renter offline:

| | before | after |
| --- | --- | --- |
| night 1 | pays `AAA`, evicts `CCC`, leaves `BBB` | pays `AAA`, evicts `BBB` and `CCC` |
| night 2 | `AAA` and nothing else, still unpaid, still rented | `AAA` evicted, the player can no longer afford it |
| night 3 | unchanged, `AAA` rented for free | nothing left |

The last rental is the interesting one. Once it is the only one left and the player cannot afford it, `limit` is set on the first iteration and there is no later rental to fall into the `else`, so it is never evicted and never charged. It sits in `rented_vehicles` and gets skipped every night from then on.

Checked by loading the real `PayRent` out of the file under Lua 5.4 and running it over several nights. 5/8 before, 8/8 after, with the two normal cases unchanged.

---

### Implementation Details

```lua
if sum > accounts.bank then
    sum = sum - rental.rent_price
    limit = true
    unrentals[#unrentals + 1] = {rental.owner, rental.plate}
end
```

That is the whole change. `unrentals` already goes into the `DELETE FROM rented_vehicles` at the end of the function, so nothing else needs touching.

Note on the second night in the table above. With the fix the last rental is evicted rather than carried, because the player no longer has the money. That matches the online branch and the intent of the function, but it does mean a renter who empties their bank account loses everything on the next run rather than keeping one vehicle indefinitely.

Not tested on a live server. It needs an offline player with several rentals and a bank balance between one and all of them.

---

### Usage Example

```
renter offline, 600 in the bank, three rentals at 500

before: AAA paid, CCC evicted, BBB neither, and BBB stays rented for free
after:  AAA paid, BBB and CCC evicted
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
