### PR TITLE
fix(esx_hud): read the version key instead of legacyversion

### DIFF
--- a/[esx_addons]/esx_hud/server/main.lua
+++ b/[esx_addons]/esx_hud/server/main.lua
@@ -38,7 +38,7 @@ VERSION = {
             return
         end
 
-        local remoteVersion = response:match("version%s+'([%d%.]+)'")
+        local remoteVersion = ("\n" .. response):match("\n%s*version%s+[\"']([%d%.]+)[\"']")
         if not remoteVersion then
             HUD:ErrorHandle(Translate("errorGetRemoteVersion"))
             return


### PR DESCRIPTION
### Description

The version checker reads the remote `fxmanifest.lua` with

```lua
local remoteVersion = response:match("version%s+'([%d%.]+)'")
```

That pattern wants a single quote. `version` is written with double quotes, `legacyversion` with single ones, and the pattern is not anchored, so `legacyversion '1.14.1'` contains a substring that matches. The checker ends up comparing the resource version against the legacy version and tells every server it is out of date.

---

### Motivation

```lua
version "1.10.2"
legacyversion '1.14.1'
```

Running the real `VERSION.Check` against the real manifest:

```
before
  [INFO] esx_hud: currentVersion1.14.1
  [INFO] esx_hud: yourVersion1.10.2
  [INFO] esx_hud: Update available: remote 1.14.1 > local 1.10.2
  [INFO] esx_hud: needUpdateResource

after
  [INFO] esx_hud: latestVersion
  [INFO] esx_hud: Up to date version (1.10.2)
```

Local and remote are both `1.10.2`. Every server sees the update warning on every start, for a resource that is already current.

There is a fix for this sitting on the `hud-fix` branch, `4412fab` from October 2025, which never made it anywhere:

```lua
local remoteVersion = response:match('version%s+["\']([%d\.]+)["\']')
```

That accepts both quote styles but is still unanchored, so it only works because `version` happens to come before `legacyversion` in the file. Swapping the two lines brings the bug straight back:

| manifest order | current | `hud-fix` | anchored |
| --- | --- | --- | --- |
| `version` then `legacyversion` | `1.14.1` | `1.10.2` | `1.10.2` |
| `legacyversion` then `version` | `1.14.1` | `1.14.1` | `1.10.2` |

---

### Implementation Details

```lua
local remoteVersion = ("\n" .. response):match("\n%s*version%s+[\"']([%d%.]+)[\"']")
```

Anchoring to the start of a line is what makes `legacyversion` stop matching, so the key order in the manifest no longer decides the result. The leading `"\n"` is there so the pattern still finds `version` when it is the very first line.

---

### Usage Example

```
] ensure esx_hud

before: [INFO] esx_hud: Update available: remote 1.14.1 > local 1.10.2
after:  [INFO] esx_hud: Up to date version (1.10.2)
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
