### PR TITLE
fix(esx_property): round the seller share before splitting the price

### DIFF
--- a/[esx_addons]/esx_property/server/main.lua
+++ b/[esx_addons]/esx_property/server/main.lua
@@ -235,7 +235,7 @@ ESX.RegisterServerCallback("esx_property:attemptSellToPlayer", function(source, 
       exports.ox_inventory:RegisterStash("property-" .. PropertyId, Properties[PropertyId].Name, 15, 100000, xTarget.identifier)
     end
     if PM.Enabled then
-      local PlayerPrice = Price * PM.SalePercentage
+      local PlayerPrice = ESX.Math.Round(Price * PM.SalePercentage)
       local SocietyPrice = Price - PlayerPrice
       TriggerEvent('esx_addonaccount:getSharedAccount', PM.society, function(account)
         account.addMoney(SocietyPrice)


### PR DESCRIPTION
### Description

When an agent sells a property to a player, the commission split rounds one half and not the other:

```lua
local PlayerPrice = Price * PM.SalePercentage
local SocietyPrice = Price - PlayerPrice
TriggerEvent('esx_addonaccount:getSharedAccount', PM.society, function(account)
  account.addMoney(SocietyPrice)
end)
xPlayer.addAccountMoney("bank", PlayerPrice, "Sold Property")
```

`addAccountMoney` rounds internally, since `round` defaults to true for every account. `addMoney` on the society account does not round at all, it just does `self.money = self.money + amount`.

---

### Motivation

Two things come out of that.

The halves stop adding up to the price. `addon_account_data.money` is an `int`, so the fractional society share is rounded on the way into the database as well, and when both halves round up a dollar appears that nobody paid. With the default `SalePercentage = 0.25` that is every price where `Price % 4 == 2`.

The society also keeps the fractional value in memory. `self.money` stays at, say, `1126.5` and is broadcast to every client with `TriggerClientEvent('esx_addonaccount:setMoney', -1, ...)`, while the database holds `1127`. The boss menu and the database disagree until the next restart, and every later `addMoney` builds on the fractional value.

---

### Implementation Details

Round the seller share first and take the society share as the remainder, so the two are exact by construction. `esx_vehicleshop` already rounds its resell price the same way:

```lua
resellPrice = ESX.Math.Round(vehicles[i].price / 100 * Config.ResellPercentage)
```

Measured over every price from 1 to 4000, with `ESX.Math.Round` and the `int` column behaviour of MariaDB reproduced from the shipped code:

| | halves do not add up | society balance fractional |
|---|---|---|
| before | 1000 of 4000 (25.0 %) | 3000 of 4000 (75.0 %) |
| after | 0 | 0 |

Worked examples:

```
price   before: seller 375, society 1124  -> 1499   (+1)
1498    after:  seller 375, society 1123  -> 1498

price   before: seller 376, society 1127  -> 1503   (+1)
1502    after:  seller 376, society 1126  -> 1502
```

The seller is never paid less than before, the rounding just moves the odd cent to the side that was already being rounded. A sweep over the other addons found no second place doing a split this way.

---

### Usage Example

```lua
-- an agent sells a property for $1502 with PlayerManagement on
-- and the default SalePercentage of 0.25

-- before: seller gets 376, society gets 1127, total 1503,
--         and the society account holds 1126.5 in memory
-- after:  seller gets 376, society gets 1126, total 1502
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
