### PR TITLE
fix(esx_mechanicjob): only report a deposit that happened

### DIFF
--- a/[esx_addons]/esx_mechanicjob/server/main.lua
+++ b/[esx_addons]/esx_mechanicjob/server/main.lua
@@ -287,14 +287,13 @@ AddEventHandler('esx_mechanicjob:putStockItems', function(itemName, count)
 		local item = inventory.getItem(itemName)
 		local playerItemCount = xPlayer.getInventoryItem(itemName).count
 
-		if item.count >= 0 and count <= playerItemCount then
+		if count > 0 and count <= playerItemCount then
 			xPlayer.removeInventoryItem(itemName, count)
 			inventory.addItem(itemName, count)
+			xPlayer.showNotification(TranslateCap('have_deposited', count, item.label))
 		else
 			xPlayer.showNotification(TranslateCap('invalid_quantity'))
 		end
-
-		xPlayer.showNotification(TranslateCap('have_deposited', count, item.label))
 	end)
 end)
 


### PR DESCRIPTION
### Description

`putStockItems` tells the player the items were deposited even when they were not, and it never checks the amount it was handed.

---

### Motivation

Two problems in the same handler.

The `have_deposited` notification sits **outside** the branch that moves the items. Depositing more than you carry prints "invalid quantity" and then, in the same breath, "you have deposited 50 Fix Tool" while the inventory is untouched. The player sees a contradiction and has to open the stock list to find out what really happened.

The guard itself is `item.count >= 0`, which reads the **society** stock. A shared stock cannot go below zero, so the condition is always true and checks nothing. The amount the player sent is never validated, so a zero or negative count walks straight into `xPlayer.removeInventoryItem`, where the core raises `Tried remove a Invalid count`. The handler dies there with a Lua error in the console instead of telling the player anything.

---

### Implementation Details

`getStockItem`, 30 lines above in the same file, already has the shape this one is missing: guard the count with `count > 0`, and put the message inside the branch that did the work. This change makes `putStockItems` match it.

The useless `item.count >= 0` is replaced by `count > 0`, not added on top of it, because the society stock check never did anything.

I drove the shipped handler against stubs, with the core's `removeInventoryItem` behaviour reproduced (it raises below one). Player starts with 10, society with 4:

| case | before | after |
|---|---|---|
| deposit 5 | booked, `have_deposited(5)` | unchanged |
| deposit 50 | `invalid_quantity` **and** `have_deposited(50)`, nothing booked | `invalid_quantity` only |
| deposit 0 | raises `Tried remove a Invalid count -> 0` | `invalid_quantity` |
| deposit -5 | raises `Tried remove a Invalid count -> -5` | `invalid_quantity` |
| deposit 10 (boundary) | booked | unchanged |

Nothing that worked before behaves differently. The two cases that changed were a console error and a false notification.

---

### Usage Example

```lua
-- player carries 10 fixtool
TriggerServerEvent('esx_mechanicjob:putStockItems', 'fixtool', 50)
-- before: "invalid quantity" followed by "you have deposited 50 Fix Tool"
-- after:  "invalid quantity"
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.

Tested headless against the shipped file, not with two clients on a live server.
