### PR TITLE
fix(esx_property): report whether the property was actually sold

### DIFF
--- a/[esx_addons]/esx_property/server/main.lua
+++ b/[esx_addons]/esx_property/server/main.lua
@@ -221,7 +221,9 @@ ESX.RegisterServerCallback("esx_property:attemptSellToPlayer", function(source, 
   local xPlayer = ESX.GetPlayerFromId(source)
   local xTarget = ESX.GetPlayerFromId(PlayerId)
   local Price = Properties[PropertyId].Price
-  if xTarget and (xTarget.getAccount("bank").money >= Price) and (xPlayer.job.name == PM.job) then
+  local canSell = xTarget ~= nil and (xTarget.getAccount("bank").money >= Price) and (xPlayer.job.name == PM.job)
+
+  if canSell then
     xTarget.removeAccountMoney("bank", Price, "Sold Property")
     Properties[PropertyId].Owner = xTarget.identifier
     Properties[PropertyId].OwnerName = xTarget.getName()
@@ -243,7 +245,7 @@ ESX.RegisterServerCallback("esx_property:attemptSellToPlayer", function(source, 
       xPlayer.addAccountMoney("bank", PlayerPrice, "Sold Property")
     end
   end
-  cb(xPlayer.getAccount("bank").money >= Price)
+  cb(canSell)
 end)
 
 -- Buy Property


### PR DESCRIPTION
### Description

`attemptSellToPlayer` tells the client whether the **agent** can afford the property, measured after the agent was paid, instead of whether the sale happened.

---

### Motivation

```lua
cb(xPlayer.getAccount("bank").money >= Price)
```

`xPlayer` is the estate agent running the command. `xTarget` is the buyer, and the buyer's money is what decides the sale. The agent's balance has nothing to do with it, and by the time this line runs the agent has already been credited the commission, so the number being compared is not even the one from the start of the call.

Both directions go wrong, and the client acts on the answer:

```lua
ESX.TriggerServerCallback("esx_property:attemptSellToPlayer", function(IsBought)
    if IsBought then
        -- refresh the property menu
    else
        ESX.ShowNotification(TranslateCap("cannot_sell"), "error")
    end
end, PropertyId, element.value)
```

An agent with a thin bank account sells a property and is told "cannot sell" while the keys have already moved. A wealthy agent gets a refreshed menu as if the sale went through when the buyer could not pay, had disconnected, or the agent was not even in the estate agent job.

---

### Implementation Details

`buyProperty`, directly above in the same file, already has the shape this one is missing: put the condition in a local before any money moves, then hand that local to `cb`. This change makes `attemptSellToPlayer` match it.

Driven against the shipped callback with a price of 1000 and the default 25 percent commission:

| case | property sold | answered before | answered after |
|---|---|---|---|
| buyer can pay, agent broke | yes | `false` | `true` |
| buyer cannot pay, agent rich | no | `true` | `false` |
| buyer can pay, agent rich | yes | `true` | `true` |
| agent has the wrong job | no | `true` | `false` |
| buyer disconnected | no | `true` | `false` |

Four of the five answers contradicted what actually happened. The one that was right is the happy path, which is why this holds up in normal use and only shows itself when something goes wrong.

---

### Usage Example

```lua
-- estate agent with an empty bank account sells a property to a buyer who can pay
-- before: "You cannot sell this property", but the buyer already owns it
-- after:  the menu refreshes and shows the new owner
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.

Nothing about who gets the property or the money changes, only the answer sent back to the client.

Tested headless against the shipped file, not with two clients on a live server.
