### PR TITLE
refactor: replace ESX.Game.SetVehicleProperties with xLib.game.setVehicleProperties across multiple addons

### DIFF
--- a/[esx_addons]/esx_adminmenu/client/helpers.lua
+++ b/[esx_addons]/esx_adminmenu/client/helpers.lua
@@ -91,7 +91,7 @@ ESX.RegisterClientCallback("esx-adminmenu:client:adminCarVehicleProps", function
 		SetVehicleNumberPlateText(vehicle, plate)
 	end
 
-	local props = ESX.Game.GetVehicleProperties(vehicle)
+	local props = xLib.game.getVehicleProperties(vehicle)
 	props.model = GetEntityModel(vehicle)
 	props.plate = ESX.Math.Trim(GetVehicleNumberPlateText(vehicle))
 

--- a/[esx_addons]/esx_adminmenu/fxmanifest.lua
+++ b/[esx_addons]/esx_adminmenu/fxmanifest.lua
@@ -7,6 +7,7 @@ description("ESX Admin Menu")
 version("0.3.2")
 
 shared_scripts({
+	"@esx_lib/imports.lua",
 	"@es_extended/imports.lua",
 	"@es_extended/locale.lua",
 	"locales/*.lua",

--- a/[esx_addons]/esx_ambulancejob/client/vehicle.lua
+++ b/[esx_addons]/esx_ambulancejob/client/vehicle.lua
@@ -238,7 +238,7 @@ function OpenShopMenu(elements, restoreCoords, shopCoords)
 					elseif element3.value == "buy" then
 						local newPlate = exports['esx_vehicleshop']:GeneratePlate()
 						local vehicle  = GetVehiclePedIsIn(playerPed, false)
-						local props    = ESX.Game.GetVehicleProperties(vehicle)
+						local props    = xLib.game.getVehicleProperties(vehicle)
 						props.plate    = newPlate
 
 						ESX.TriggerServerCallback('esx_ambulancejob:buyJobVehicle', function (bought)

--- a/[esx_addons]/esx_ambulancejob/client/vehicle.lua
+++ b/[esx_addons]/esx_ambulancejob/client/vehicle.lua
@@ -84,7 +84,7 @@ function OpenVehicleSpawnerMenu(type, hospital, part, partNum)
 
 									ESX.Game.SpawnVehicle(elementG.model, spawnPoint.coords, spawnPoint.heading, function(vehicle)
 										local vehicleProps = allVehicleProps[elementG.plate]
-										ESX.Game.SetVehicleProperties(vehicle, vehicleProps)
+										xLib.game.setVehicleProperties(vehicle, vehicleProps)
 
 										TriggerServerEvent('esx_vehicleshop:setJobVehicleState', elementG.plate, false)
 										ESX.ShowNotification(TranslateCap('garage_released'))
@@ -215,7 +215,7 @@ function OpenShopMenu(elements, restoreCoords, shopCoords)
 					SetModelAsNoLongerNeeded(element.model)
 
 					if element.props then
-						ESX.Game.SetVehicleProperties(vehicle, element.props)
+						xLib.game.setVehicleProperties(vehicle, element.props)
 					end
 				end)
 

--- a/[esx_addons]/esx_ambulancejob/fxmanifest.lua
+++ b/[esx_addons]/esx_ambulancejob/fxmanifest.lua
@@ -6,6 +6,7 @@ legacyversion '1.14.1'
 lua54 'yes'
 
 shared_scripts {
+	'@esx_lib/imports.lua',
 	'@es_extended/imports.lua',
 	'@es_extended/locale.lua',
 	'locales/*.lua',

--- a/[esx_addons]/esx_boat/client/main.lua
+++ b/[esx_addons]/esx_boat/client/main.lua
@@ -49,7 +49,7 @@ function OpenBoatShop(shop)
 						if element3.value == "buy" then
 							local plate = exports['esx_vehicleshop']:GeneratePlate()
 							local vehicle = GetVehiclePedIsIn(playerPed, false)
-							local props = ESX.Game.GetVehicleProperties(vehicle)
+							local props = xLib.game.getVehicleProperties(vehicle)
 							props.plate = plate
 
 							ESX.TriggerServerCallback('esx_boat:buyBoat', function(bought)
@@ -175,7 +175,7 @@ function OpenLicenceMenu(shop)
 end
 
 function StoreBoatInGarage(vehicle, teleportCoords)
-	local vehicleProps = ESX.Game.GetVehicleProperties(vehicle)
+	local vehicleProps = xLib.game.getVehicleProperties(vehicle)
 
 	ESX.TriggerServerCallback('esx_boat:storeVehicle', function (rowsChanged)
 		if rowsChanged > 0 then

--- a/[esx_addons]/esx_boat/client/main.lua
+++ b/[esx_addons]/esx_boat/client/main.lua
@@ -36,7 +36,7 @@ function OpenBoatShop(shop)
 					FreezeEntityPosition(vehicle, true)
 
 					if element.props then
-						ESX.Game.SetVehicleProperties(vehicle, element.props)
+						xLib.game.setVehicleProperties(vehicle, element.props)
 					end
 
 					local elements3 = {
@@ -119,7 +119,7 @@ function OpenBoatGarage(garage)
 
 					ESX.Game.SpawnVehicle(vehicleProps.model, garage.SpawnPoint, garage.SpawnPoint.w, function(vehicle)
 						TaskWarpPedIntoVehicle(playerPed, vehicle, -1)
-						ESX.Game.SetVehicleProperties(vehicle, vehicleProps)
+						xLib.game.setVehicleProperties(vehicle, vehicleProps)
 					end)
 
 					ESX.CloseContext()

--- a/[esx_addons]/esx_boat/fxmanifest.lua
+++ b/[esx_addons]/esx_boat/fxmanifest.lua
@@ -7,7 +7,10 @@ lua54 'yes'
 version '1.0'
 legacyversion '1.14.1'
 
-shared_script '@es_extended/imports.lua'
+shared_scripts {
+	'@esx_lib/imports.lua',
+	'@es_extended/imports.lua'
+}
 
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',

--- a/[esx_addons]/esx_garage/client/init.lua
+++ b/[esx_addons]/esx_garage/client/init.lua
@@ -264,7 +264,7 @@ local function storeCurrentVehicle()
         return ESX.ShowNotification(TranslateCap("not_in_vehicle"), "error")
     end
 
-    local props = ESX.Game.GetVehicleProperties(vehicle)
+    local props = xLib.game.getVehicleProperties(vehicle)
     if not props or not props.plate then
         return
     end

--- a/[esx_addons]/esx_garage/fxmanifest.lua
+++ b/[esx_addons]/esx_garage/fxmanifest.lua
@@ -19,6 +19,7 @@ files {
 }
 
 shared_scripts {
+    '@esx_lib/imports.lua',
     '@es_extended/imports.lua',
     '@es_extended/locale.lua',
     'locales/*.lua',

--- a/[esx_addons]/esx_lscustom/client/main.lua
+++ b/[esx_addons]/esx_lscustom/client/main.lua
@@ -13,7 +13,7 @@ RegisterNetEvent('esx_lscustom:installMod')
 AddEventHandler('esx_lscustom:installMod', function()
     local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
     local NetId = NetworkGetNetworkIdFromEntity(vehicle)
-    myCar = ESX.Game.GetVehicleProperties(vehicle)
+    myCar = xLib.game.getVehicleProperties(vehicle)
     TriggerServerEvent('esx_lscustom:refreshOwnedVehicle', myCar, NetId)
 end)
 
@@ -82,7 +82,7 @@ function OpenLSMenu(elems, menuName, menuTitle, parent)
 
                 if data.current.label == TranslateCap('by_default') or string.match(data.current.label, TranslateCap('installed')) then
                     ESX.ShowNotification(TranslateCap('already_own', data.current.label))
-                    myCar = ESX.Game.GetVehicleProperties(vehicle)
+                    myCar = xLib.game.getVehicleProperties(vehicle)
                     TriggerServerEvent('esx_lscustom:refreshOwnedVehicle', myCar, NetworkGetNetworkIdFromEntity(vehicle))
                 else
                     local vehiclePrice = 50000
@@ -189,7 +189,7 @@ function GetAction(data)
 
     local playerPed = PlayerPedId()
     local vehicle = GetVehiclePedIsIn(playerPed, false)
-    local currentMods = ESX.Game.GetVehicleProperties(vehicle)
+    local currentMods = xLib.game.getVehicleProperties(vehicle)
     if data.value == 'modSpeakers' or data.value == 'modTrunk' or data.value == 'modHydrolic' or data.value ==
         'modEngineBlock' or data.value == 'modAirFilter' or data.value == 'modStruts' or data.value == 'modTank' then
         SetVehicleDoorOpen(vehicle, 4, false)
@@ -579,7 +579,7 @@ CreateThread(function()
 
                                 local vehicle = GetVehiclePedIsIn(playerPed, false)
                                 FreezeEntityPosition(vehicle, true)
-                                myCar = ESX.Game.GetVehicleProperties(vehicle)
+                                myCar = xLib.game.getVehicleProperties(vehicle)
                                 
                                 local netId = NetworkGetNetworkIdFromEntity(vehicle)
                                 TriggerServerEvent('esx_lscustom:startModing', myCar, netId)

--- a/[esx_addons]/esx_lscustom/client/main.lua
+++ b/[esx_addons]/esx_lscustom/client/main.lua
@@ -21,7 +21,7 @@ RegisterNetEvent('esx_lscustom:restoreMods', function(netId, props)
     local xVehicle = NetworkGetEntityFromNetworkId(netId)
     if props ~= nil then
         if DoesEntityExist(xVehicle) then
-            ESX.Game.SetVehicleProperties(xVehicle, props)
+            xLib.game.setVehicleProperties(xVehicle, props)
         end
     end
 end)
@@ -32,7 +32,7 @@ AddEventHandler('esx_lscustom:cancelInstallMod', function()
     if (GetPedInVehicleSeat(vehicle, -1) ~= PlayerPedId()) then
         vehicle = GetPlayersLastVehicle(PlayerPedId())
     end
-    ESX.Game.SetVehicleProperties(vehicle, myCar)
+    xLib.game.setVehicleProperties(vehicle, myCar)
     if not (myCar.modTurbo) then
         ToggleVehicleMod(vehicle, 18, false)
     end
@@ -152,7 +152,7 @@ function UpdateMods(data)
                 props['modBackWheels'] = data.modNum
             end
 
-            ESX.Game.SetVehicleProperties(vehicle, props)
+            xLib.game.setVehicleProperties(vehicle, props)
             props = {}
         elseif data.modType == 'neonColor' then
             if data.modNum[1] == 0 and data.modNum[2] == 0 and data.modNum[3] == 0 then
@@ -160,11 +160,11 @@ function UpdateMods(data)
             else
                 props['neonEnabled'] = {true, true, true, true}
             end
-            ESX.Game.SetVehicleProperties(vehicle, props)
+            xLib.game.setVehicleProperties(vehicle, props)
             props = {}
         elseif data.modType == 'tyreSmokeColor' then
             props['modSmokeEnabled'] = true
-            ESX.Game.SetVehicleProperties(vehicle, props)
+            xLib.game.setVehicleProperties(vehicle, props)
             props = {}
         elseif data.modType == 'xenonColor' then
             if data.modNum then
@@ -172,12 +172,12 @@ function UpdateMods(data)
             else
                 props['modXenon'] = false
             end
-            ESX.Game.SetVehicleProperties(vehicle, props)
+            xLib.game.setVehicleProperties(vehicle, props)
             props = {}
         end
 
         props[data.modType] = data.modNum
-        ESX.Game.SetVehicleProperties(vehicle, props)
+        xLib.game.setVehicleProperties(vehicle, props)
     end
 end
 
@@ -376,7 +376,7 @@ function GetAction(data)
                     local props = {}
 
                     props['wheels'] = v.wheelType
-                    ESX.Game.SetVehicleProperties(vehicle, props)
+                    xLib.game.setVehicleProperties(vehicle, props)
 
                     local modCount = GetNumVehicleMods(vehicle, v.modType)
                     for j = 0, modCount, 1 do
@@ -404,7 +404,7 @@ function GetAction(data)
                     local props = {}
 
                     props['wheels'] = v.wheelType
-                    ESX.Game.SetVehicleProperties(vehicle, props)
+                    xLib.game.setVehicleProperties(vehicle, props)
 
                     local modCount = GetNumVehicleMods(vehicle, v.modType)
                     for j = 0, modCount, 1 do

--- a/[esx_addons]/esx_lscustom/fxmanifest.lua
+++ b/[esx_addons]/esx_lscustom/fxmanifest.lua
@@ -7,7 +7,10 @@ lua54 'yes'
 version '1.0'
 legacyversion '1.14.1'
 
-shared_script '@es_extended/imports.lua'
+shared_scripts {
+	'@esx_lib/imports.lua',
+	'@es_extended/imports.lua'
+}
 
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',

--- a/[esx_addons]/esx_mechanicjob/client/main.lua
+++ b/[esx_addons]/esx_mechanicjob/client/main.lua
@@ -908,7 +908,7 @@ CreateThread(function()
 					OpenMechanicCraftMenu()
 				elseif CurrentAction == 'delete_vehicle' then
 					if Config.EnableSocietyOwnedVehicles then
-						local vehicleProps = ESX.Game.GetVehicleProperties(CurrentActionData.vehicle)
+						local vehicleProps = xLib.game.getVehicleProperties(CurrentActionData.vehicle)
 						TriggerServerEvent('esx_society:putVehicleInGarage', 'mechanic', vehicleProps)
 					else
 						local entityModel = GetEntityModel(CurrentActionData.vehicle)

--- a/[esx_addons]/esx_mechanicjob/client/main.lua
+++ b/[esx_addons]/esx_mechanicjob/client/main.lua
@@ -93,7 +93,7 @@ function OpenMechanicActionsMenu()
 
 						ESX.Game.SpawnVehicle(vehicleProps.model, Config.Zones.VehicleSpawnPoint.Pos, 270.0,
 							function(vehicle)
-								ESX.Game.SetVehicleProperties(vehicle, vehicleProps)
+								xLib.game.setVehicleProperties(vehicle, vehicleProps)
 								local playerPed = PlayerPedId()
 								TaskWarpPedIntoVehicle(playerPed, vehicle, -1)
 							end)

--- a/[esx_addons]/esx_mechanicjob/fxmanifest.lua
+++ b/[esx_addons]/esx_mechanicjob/fxmanifest.lua
@@ -7,7 +7,10 @@ lua54 'yes'
 version '1.0'
 legacyversion '1.14.1'
 
-shared_script '@es_extended/imports.lua'
+shared_scripts {
+	'@esx_lib/imports.lua',
+	'@es_extended/imports.lua'
+}
 
 client_scripts {
 	'@es_extended/locale.lua',

--- a/[esx_addons]/esx_policejob/client/main.lua
+++ b/[esx_addons]/esx_policejob/client/main.lua
@@ -324,7 +324,7 @@ function OpenPoliceActionsMenu()
 					LookupVehicle(element3)
 				elseif DoesEntityExist(vehicle) then
 					if action == 'vehicle_infos' then
-						local vehicleData = ESX.Game.GetVehicleProperties(vehicle)
+						local vehicleData = xLib.game.getVehicleProperties(vehicle)
 						OpenVehicleInfosMenu(vehicleData)
 					elseif action == 'hijack_vehicle' then
 						if IsAnyVehicleNearPoint(coords.x, coords.y, coords.z, 3.0) then

--- a/[esx_addons]/esx_policejob/client/vehicle.lua
+++ b/[esx_addons]/esx_policejob/client/vehicle.lua
@@ -243,7 +243,7 @@ function OpenShopMenu(elements, restoreCoords, shopCoords)
 					elseif element3.value == "buy" then
 						local newPlate = exports['esx_vehicleshop']:GeneratePlate()
 						local vehicle  = GetVehiclePedIsIn(playerPed, false)
-						local props    = ESX.Game.GetVehicleProperties(vehicle)
+						local props    = xLib.game.getVehicleProperties(vehicle)
 						props.plate    = newPlate
 
 						ESX.TriggerServerCallback('esx_policejob:buyJobVehicle', function (bought)

--- a/[esx_addons]/esx_policejob/client/vehicle.lua
+++ b/[esx_addons]/esx_policejob/client/vehicle.lua
@@ -89,7 +89,7 @@ function OpenVehicleSpawnerMenu(type, station, part, partNum)
 
 									ESX.Game.SpawnVehicle(elementG.model, spawnPoint.coords, spawnPoint.heading, function(vehicle)
 										local vehicleProps = allVehicleProps[elementG.plate]
-										ESX.Game.SetVehicleProperties(vehicle, vehicleProps)
+										xLib.game.setVehicleProperties(vehicle, vehicleProps)
 
 										TriggerServerEvent('esx_vehicleshop:setJobVehicleState', elementG.plate, false)
 										ESX.ShowNotification(TranslateCap('garage_released'))
@@ -220,7 +220,7 @@ function OpenShopMenu(elements, restoreCoords, shopCoords)
 					SetModelAsNoLongerNeeded(element.model)
 
 					if element.props then
-						ESX.Game.SetVehicleProperties(vehicle, element.props)
+						xLib.game.setVehicleProperties(vehicle, element.props)
 					end
 				end)
 

--- a/[esx_addons]/esx_policejob/fxmanifest.lua
+++ b/[esx_addons]/esx_policejob/fxmanifest.lua
@@ -7,7 +7,10 @@ lua54 'yes'
 version '1.0.2'
 legacyversion '1.14.1'
 
-shared_script '@es_extended/imports.lua'
+shared_scripts {
+	'@esx_lib/imports.lua',
+	'@es_extended/imports.lua'
+}
 
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',

--- a/[esx_addons]/esx_property/client/main.lua
+++ b/[esx_addons]/esx_property/client/main.lua
@@ -736,7 +736,7 @@ function AccessGarage(PropertyId)
             ESX.Game.SpawnVehicle(element.Properties.model, Properties[PropertyId].garage.pos, Properties[PropertyId].garage.Heading,
               function(vehicle)
                 SetEntityAsMissionEntity(vehicle, true, true)
-                ESX.Game.SetVehicleProperties(vehicle, element.Properties)
+                xLib.game.setVehicleProperties(vehicle, element.Properties)
                 TaskWarpPedIntoVehicle(ESX.PlayerData.ped, vehicle, -1)
                 SetModelAsNoLongerNeeded(element.Properties.model)
                 TriggerServerEvent("esx_property:SetVehicleOut", PropertyId, element.index)

--- a/[esx_addons]/esx_property/client/main.lua
+++ b/[esx_addons]/esx_property/client/main.lua
@@ -704,7 +704,7 @@ end
 function StoreVehicle(PropertyId)
   local Vehicle = GetVehiclePedIsIn(ESX.PlayerData.ped, false)
   if Vehicle then
-    local VehProperties = ESX.Game.GetVehicleProperties(Vehicle)
+    local VehProperties = xLib.game.getVehicleProperties(vehicle)
     VehProperties.DisplayName = GetLabelText(GetDisplayNameFromVehicleModel(VehProperties.model))
     ESX.TriggerServerCallback("esx_property:StoreVehicle", function(result)
       if result then

--- a/[esx_addons]/esx_property/fxmanifest.lua
+++ b/[esx_addons]/esx_property/fxmanifest.lua
@@ -25,7 +25,7 @@ description 'Allows players to buy/sell houses, aswell as furnish them'
 version '2.0'
 legacyversion '1.14.1'
 
-shared_scripts { '@es_extended/imports.lua', '@es_extended/locale.lua', 'locales/*.lua' }
+shared_scripts { '@esx_lib/imports.lua', '@es_extended/imports.lua', '@es_extended/locale.lua', 'locales/*.lua' }
 file "client/html/copy.html"
 ui_page "client/html/copy.html"
 

--- a/[esx_addons]/esx_taxijob/client/main.lua
+++ b/[esx_addons]/esx_taxijob/client/main.lua
@@ -194,7 +194,7 @@ function DeleteJobVehicle()
     local playerPed = PlayerPedId()
 
     if Config.EnableSocietyOwnedVehicles then
-        local vehicleProps = ESX.Game.GetVehicleProperties(CurrentActionData.vehicle)
+        local vehicleProps = xLib.game.getVehicleProperties(CurrentActionData.vehicle)
         TriggerServerEvent('esx_society:putVehicleInGarage', 'taxi', vehicleProps)
         ESX.Game.DeleteVehicle(CurrentActionData.vehicle)
     else

--- a/[esx_addons]/esx_taxijob/fxmanifest.lua
+++ b/[esx_addons]/esx_taxijob/fxmanifest.lua
@@ -7,7 +7,10 @@ lua54 'yes'
 version '1.0'
 legacyversion '1.14.1'
 
-shared_script '@es_extended/imports.lua'
+shared_script {
+	'@esx_lib/imports.lua',
+	'@es_extended/imports.lua'
+}
 
 client_scripts {
 	'@es_extended/locale.lua',

--- a/[esx_addons]/esx_vehicleshop/client/main.lua
+++ b/[esx_addons]/esx_vehicleshop/client/main.lua
@@ -358,7 +358,7 @@ function OpenResellerMenu()
 
 				if closestPlayer ~= -1 and closestDistance < 3 then
 					local newPlate = GeneratePlate()
-					local vehicleProps = ESX.Game.GetVehicleProperties(currentDisplayVehicle)
+					local vehicleProps = xLib.game.getVehicleProperties(currentDisplayVehicle)
 					vehicleProps.plate = newPlate
 					SetVehicleNumberPlateText(currentDisplayVehicle, newPlate)
 					TriggerServerEvent('esx_vehicleshop:setVehicleOwnedPlayerId', GetPlayerServerId(closestPlayer), vehicleProps, CurrentVehicleData.model, CurrentVehicleData.name)

--- a/[esx_addons]/esx_vehicleshop/fxmanifest.lua
+++ b/[esx_addons]/esx_vehicleshop/fxmanifest.lua
@@ -5,7 +5,10 @@ description 'Allows Players to buy & sell vehicles'
 version '1.0'
 legacyversion '1.14.1'
 
-shared_script '@es_extended/imports.lua'
+shared_script {
+	'@esx_lib/imports.lua',
+	'@es_extended/imports.lua'
+}
 
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Replaces the removed ``ESX.Game.SetVehicleProperties`` and ``ESX.Game.GetVehicleProperties`` call with ``xLib.game.setVehicleProperties`` and ``xLib.game.getVehicleProperties`` across ESX addons. The old ``ESX.Game`` method was removed from es_extended.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

Since ESX 1.14.x, ``ESX.Game.SetVehicleProperties`` and ``ESX.Game.GetVehicleProperties`` no longer exists. This causes the following error

```lua 
SCRIPT ERROR: attempt to call a nil value (field 'setVehicleProperties')
SCRIPT ERROR: attempt to call a nil value (field 'getVehicleProperties')
```

``xLib.game.setVehicleProperties`` and ``xLib.game.getVehicleProperties`` is the intended replacement and is already available globally via the esx_lib dependency.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- Replaced ``ESX.Game.SetVehicleProperties(vehicle, value)`` with ``xLib.game.setVehicleProperties(vehicle, value)``.
- Replaced ``ESX.Game.GetVehicleProperties(vehicle)`` with ``xLib.game.getVehicleProperties(vehicle,)``.
- ``xLib`` is guaranteed to be present because ``esx_lib`` is a required dependency of the ESX.
- Zero breaking changes — the function signature is identical.

---

### Usage Example

```lua
-- Add example usage here
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
